### PR TITLE
feat: KCL manifests with HTTPRoute and updated README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,13 +12,137 @@ gitops cluster configuration management
   </p>
 </div>
 
+## FEATURES
+
+| Feature | Description |
+|---------|-------------|
+| IP Address Management | Allocate and track IPs across Kubernetes clusters |
+| gRPC API | Programmatic access on port `:50051` |
+| REST API | JSON endpoints on port `:8080` |
+| HTMX Dashboard | Web UI for IP pool visualization and management |
+| Dual Storage | Filesystem (YAML) or Kubernetes CRD backend |
+| KCL Manifests | Type-safe Kubernetes deployment with KCL |
+
 ## DEPLOYMENT
+
+<details><summary>KCL (RECOMMENDED)</summary>
+
+### Render manifests
+
+```bash
+cd kcl && kcl run
+```
+
+### Render with custom config
+
+```bash
+kcl run -D config.image=ghcr.io/stuttgart-things/clusterbook/clusterbook:v1.5.1 \
+        -D config.namespace=clusterbook \
+        -D config.configName=networks-labul
+```
+
+### Render with HTTPRoute (Gateway API)
+
+```bash
+kcl run -D config.httpRouteEnabled=true \
+        -D config.httpRouteParentRefName=my-gateway \
+        -D config.httpRouteHostname=clusterbook.example.com
+```
+
+### Apply to cluster
+
+```bash
+cd kcl && kcl run | kubectl apply -f -
+```
+
+</details>
+
+<details><summary>HELM (LEGACY)</summary>
 
 ```bash
 helmfile apply -f helm/helmfile.yaml -e dev # example env
 ```
 
+</details>
+
 ## USAGE
+
+<details><summary>WEB UI (HTMX)</summary>
+
+The HTMX dashboard is available on port `:8080` (configurable via `HTTP_PORT`).
+
+- **Dashboard**: `http://localhost:8080/` - overview of all network pools
+- **Network Detail**: `http://localhost:8080/network/10.31.103` - IP table with inline assign/release
+
+</details>
+
+<details><summary>REST API</summary>
+
+### List all network pools
+
+```bash
+curl http://localhost:8080/api/v1/networks
+```
+
+### List IPs in a network
+
+```bash
+curl http://localhost:8080/api/v1/networks/10.31.103/ips
+```
+
+### Assign an IP
+
+```bash
+curl -X POST http://localhost:8080/api/v1/networks/10.31.103/assign \
+  -H "Content-Type: application/json" \
+  -d '{"ip": "10.31.103.6", "cluster": "my-cluster", "status": "ASSIGNED"}'
+```
+
+### Release an IP
+
+```bash
+curl -X POST http://localhost:8080/api/v1/networks/10.31.103/release \
+  -H "Content-Type: application/json" \
+  -d '{"ip": "10.31.103.6"}'
+```
+
+</details>
+
+<details><summary>gRPC</summary>
+
+```bash
+# Get available IPs
+grpcurl -plaintext localhost:50051 ipservice.IpService/GetIpAddressRange \
+  -d '{"countIpAddresses": 2, "networkKey": "10.31.103"}'
+
+# Assign IPs to a cluster
+grpcurl -plaintext localhost:50051 ipservice.IpService/SetClusterInfo \
+  -d '{"ipAddressRange": "10.31.103.6", "clusterName": "my-cluster", "status": "ASSIGNED"}'
+```
+
+</details>
+
+<details><summary>CLI (machineshop)</summary>
+
+### GET IPS
+
+```bash
+machineshop get \
+--system=ips \
+--destination=clusterbook.172.18.0.5.nip.io \
+--path=10.31.103 \
+--output=2
+```
+
+```bash
+machineshop push \
+--target=ips \
+--destination=clusterbook.172.18.0.5.nip.io \
+--artifacts="10.31.103.9;10.31.103.10" \
+--assignee=app1
+```
+
+</details>
 
 <details><summary>CREATE CR</summary>
 
@@ -67,27 +191,16 @@ EOF
 
 </details>
 
-<details><summary>CLI</summary>
+## CONFIGURATION
 
-### GET IPS
-
-```bash
-machineshop get \
---system=ips \
---destination=clusterbook.172.18.0.5.nip.io \
---path=10.31.103 \
---output=2
-```
-
-```bash
-machineshop push \
---target=ips \
---destination=clusterbook.172.18.0.5.nip.io \
---artifacts="10.31.103.9;10.31.103.10" \
---assignee=app1
-```
-
-</details>
+| Environment Variable | Description | Default |
+|---------------------|-------------|---------|
+| `LOAD_CONFIG_FROM` | Config source: `disk` or `cr` | - |
+| `CONFIG_LOCATION` | File path or K8s namespace | - |
+| `CONFIG_NAME` | File name or resource name | - |
+| `SERVER_PORT` | gRPC server port | `50051` |
+| `HTTP_PORT` | HTTP/HTMX server port | `8080` |
+| `KUBECONFIG` | K8s config path (for CR backend) | - |
 
 ## DEV TASKS
 
@@ -126,6 +239,7 @@ CONFIG_LOCATION=clusterbook #namespace
 CONFIG_NAME=networks-labul #resource-name
 
 SERVER_PORT=50051
+HTTP_PORT=8080
 
 #CLUSTERBOOK_SERVER=localhost:50051
 #SECURE_CONNECTION=false

--- a/kcl/configmap.k
+++ b/kcl/configmap.k
@@ -1,0 +1,24 @@
+"""
+ConfigMap for clusterbook
+"""
+
+import labels
+
+config = labels.config
+
+configMap = {
+    apiVersion: "v1"
+    kind: "ConfigMap"
+    metadata: {
+        name: "{}-config".format(config.name)
+        namespace: config.namespace
+        labels: labels.commonLabels
+    }
+    data: {
+        LOAD_CONFIG_FROM: config.loadConfigFrom
+        CONFIG_LOCATION: config.configLocation
+        CONFIG_NAME: config.configName
+        SERVER_PORT: config.serverPort
+        HTTP_PORT: str(config.httpPort)
+    }
+}

--- a/kcl/deploy.k
+++ b/kcl/deploy.k
@@ -1,0 +1,126 @@
+"""
+Deployment for clusterbook
+"""
+
+import labels
+
+config = labels.config
+
+deployment = {
+    apiVersion: "apps/v1"
+    kind: "Deployment"
+    metadata: {
+        name: config.name
+        namespace: config.namespace
+        labels: labels.commonLabels
+    }
+    spec: {
+        replicas: config.replicas
+        selector: {
+            matchLabels: labels.selectorLabels
+        }
+        strategy: {
+            type: "RollingUpdate"
+            rollingUpdate: {
+                maxSurge: 1
+                maxUnavailable: 0
+            }
+        }
+        template: {
+            metadata: {
+                labels: labels.commonLabels
+            }
+            spec: {
+                serviceAccountName: config.name
+                containers: [
+                    {
+                        name: config.name
+                        image: config.image
+                        imagePullPolicy: config.imagePullPolicy
+                        ports: [
+                            {
+                                name: "grpc"
+                                containerPort: config.grpcPort
+                                protocol: "TCP"
+                            }
+                            {
+                                name: "http"
+                                containerPort: config.httpPort
+                                protocol: "TCP"
+                            }
+                        ]
+                        envFrom: [
+                            {
+                                configMapRef: {
+                                    name: "{}-config".format(config.name)
+                                }
+                            }
+                        ]
+                        resources: {
+                            requests: {
+                                cpu: config.cpuRequest
+                                memory: config.memoryRequest
+                            }
+                            limits: {
+                                cpu: config.cpuLimit
+                                memory: config.memoryLimit
+                            }
+                        }
+                        livenessProbe: {
+                            httpGet: {
+                                path: "/"
+                                port: "http"
+                            }
+                            initialDelaySeconds: 10
+                            periodSeconds: 10
+                            timeoutSeconds: 5
+                            failureThreshold: 3
+                        }
+                        readinessProbe: {
+                            httpGet: {
+                                path: "/"
+                                port: "http"
+                            }
+                            initialDelaySeconds: 5
+                            periodSeconds: 5
+                            timeoutSeconds: 3
+                            failureThreshold: 3
+                        }
+                        securityContext: {
+                            readOnlyRootFilesystem: True
+                            runAsNonRoot: True
+                            allowPrivilegeEscalation: False
+                            capabilities: {
+                                drop: ["ALL"]
+                            }
+                        }
+                    }
+                ]
+                securityContext: {
+                    runAsNonRoot: True
+                    runAsUser: 65532
+                    runAsGroup: 65532
+                    fsGroup: 65532
+                    seccompProfile: {
+                        type: "RuntimeDefault"
+                    }
+                }
+                affinity: {
+                    podAntiAffinity: {
+                        preferredDuringSchedulingIgnoredDuringExecution: [
+                            {
+                                weight: 100
+                                podAffinityTerm: {
+                                    labelSelector: {
+                                        matchLabels: labels.selectorLabels
+                                    }
+                                    topologyKey: "kubernetes.io/hostname"
+                                }
+                            }
+                        ]
+                    }
+                }
+            }
+        }
+    }
+}

--- a/kcl/httproute.k
+++ b/kcl/httproute.k
@@ -1,0 +1,53 @@
+"""
+HTTPRoute (Gateway API) for clusterbook HTMX frontend
+"""
+
+import labels
+
+config = labels.config
+
+_hostname = config.httpRouteHostname
+
+httproute = {
+    apiVersion: "gateway.networking.k8s.io/v1"
+    kind: "HTTPRoute"
+    metadata: {
+        name: config.name
+        namespace: config.namespace
+        labels: labels.commonLabels
+        if config.annotations or config.httpRouteAnnotations:
+            annotations: {
+                **config.annotations
+                **config.httpRouteAnnotations
+            }
+    }
+    spec: {
+        parentRefs: [
+            {
+                name: config.httpRouteParentRefName
+                if config.httpRouteParentRefNamespace:
+                    namespace: config.httpRouteParentRefNamespace
+            }
+        ]
+        if _hostname:
+            hostnames: [_hostname]
+        rules: [
+            {
+                matches: [
+                    {
+                        path: {
+                            type: "PathPrefix"
+                            value: "/"
+                        }
+                    }
+                ]
+                backendRefs: [
+                    {
+                        name: "{}-http".format(config.name)
+                        port: config.httpServicePort
+                    }
+                ]
+            }
+        ]
+    }
+} if config.httpRouteEnabled else None

--- a/kcl/kcl.mod
+++ b/kcl/kcl.mod
@@ -1,0 +1,12 @@
+[package]
+name = "deploy-clusterbook"
+version = "0.1.0"
+description = "KCL module for deploying clusterbook on Kubernetes"
+
+[dependencies]
+k8s = "1.31"
+
+[profile]
+entries = [
+    "main.k"
+]

--- a/kcl/kcl.mod.lock
+++ b/kcl/kcl.mod.lock
@@ -1,0 +1,9 @@
+[dependencies]
+  [dependencies.k8s]
+    name = "k8s"
+    full_name = "k8s_1.31"
+    version = "1.31"
+    sum = "LqN5u8Jvj1/2ozrLL0PafXTmtqj7HfxYCHwnEf0WmkQ="
+    reg = "ghcr.io"
+    repo = "kcl-lang/k8s"
+    oci_tag = "1.31"

--- a/kcl/labels.k
+++ b/kcl/labels.k
@@ -1,0 +1,59 @@
+"""
+Common labels and configuration for clusterbook resources
+"""
+
+import schema
+
+# Get command-line options
+_image = option("config.image")
+_namespace = option("config.namespace")
+_loadConfigFrom = option("config.loadConfigFrom")
+_configLocation = option("config.configLocation")
+_configName = option("config.configName")
+_serverPort = option("config.serverPort")
+_httpRouteEnabled = option("config.httpRouteEnabled")
+_httpRouteParentRefName = option("config.httpRouteParentRefName")
+_httpRouteParentRefNamespace = option("config.httpRouteParentRefNamespace")
+_httpRouteHostname = option("config.httpRouteHostname")
+_httpRouteAnnotations = option("config.httpRouteAnnotations") or {}
+
+# Config instance with command-line overrides
+config: schema.ClusterBook = schema.ClusterBook {
+    if _image:
+        image = _image
+    if _namespace:
+        namespace = _namespace
+    if _loadConfigFrom:
+        loadConfigFrom = _loadConfigFrom
+    if _configLocation:
+        configLocation = _configLocation
+    if _configName:
+        configName = _configName
+    if _serverPort:
+        serverPort = _serverPort
+    if _httpRouteEnabled:
+        httpRouteEnabled = _httpRouteEnabled in [True, "True", "true"]
+    if _httpRouteParentRefName:
+        httpRouteParentRefName = _httpRouteParentRefName
+    if _httpRouteParentRefNamespace:
+        httpRouteParentRefNamespace = _httpRouteParentRefNamespace
+    if _httpRouteHostname:
+        httpRouteHostname = _httpRouteHostname
+    if _httpRouteAnnotations:
+        httpRouteAnnotations = _httpRouteAnnotations
+}
+
+# Common labels applied to all resources
+commonLabels = {
+    "app.kubernetes.io/name": config.name
+    "app.kubernetes.io/instance": config.name
+    "app.kubernetes.io/component": "ipam"
+    "app.kubernetes.io/part-of": "clusterbook"
+    **config.labels
+}
+
+# Selector labels for pods
+selectorLabels = {
+    "app.kubernetes.io/name": config.name
+    "app.kubernetes.io/instance": config.name
+}

--- a/kcl/main.k
+++ b/kcl/main.k
@@ -1,0 +1,27 @@
+"""
+Main entry point for clusterbook Kubernetes deployment
+Imports all resources and exports manifests
+"""
+
+import namespace
+import serviceaccount
+import configmap
+import deploy
+import service
+import rbac
+import httproute
+
+# Export all manifests (filter out None values)
+manifests = [
+    m for m in [
+        namespace.namespace
+        serviceaccount.serviceAccount
+        configmap.configMap
+        rbac.role
+        rbac.roleBinding
+        deploy.deployment
+        service.serviceGrpc
+        service.serviceHttp
+        httproute.httproute
+    ] if m
+]

--- a/kcl/namespace.k
+++ b/kcl/namespace.k
@@ -1,0 +1,16 @@
+"""
+Namespace for clusterbook
+"""
+
+import labels
+
+config = labels.config
+
+namespace = {
+    apiVersion: "v1"
+    kind: "Namespace"
+    metadata: {
+        name: config.namespace
+        labels: labels.commonLabels
+    }
+}

--- a/kcl/rbac.k
+++ b/kcl/rbac.k
@@ -1,0 +1,46 @@
+"""
+RBAC resources for clusterbook (Role + RoleBinding for NetworkConfig CRs)
+"""
+
+import labels
+
+config = labels.config
+
+role = {
+    apiVersion: "rbac.authorization.k8s.io/v1"
+    kind: "Role"
+    metadata: {
+        name: config.name
+        namespace: config.namespace
+        labels: labels.commonLabels
+    }
+    rules: [
+        {
+            apiGroups: [config.networkConfigApiGroup]
+            resources: ["networkconfigs"]
+            verbs: ["get", "list", "watch", "create", "update"]
+        }
+    ]
+}
+
+roleBinding = {
+    apiVersion: "rbac.authorization.k8s.io/v1"
+    kind: "RoleBinding"
+    metadata: {
+        name: config.name
+        namespace: config.namespace
+        labels: labels.commonLabels
+    }
+    subjects: [
+        {
+            kind: "ServiceAccount"
+            name: config.name
+            namespace: config.namespace
+        }
+    ]
+    roleRef: {
+        kind: "Role"
+        name: config.name
+        apiGroup: "rbac.authorization.k8s.io"
+    }
+}

--- a/kcl/schema.k
+++ b/kcl/schema.k
@@ -1,0 +1,57 @@
+"""
+Schema definition for clusterbook deployment configuration
+"""
+
+schema ClusterBook:
+    """Configuration for clusterbook Kubernetes deployment"""
+
+    # Metadata
+    name: str = "clusterbook"
+    namespace: str = "clusterbook"
+
+    # Image
+    image: str = "ghcr.io/stuttgart-things/clusterbook/clusterbook:latest"
+    imagePullPolicy: str = "Always"
+
+    # Replicas and resources
+    replicas: int = 1
+    cpuRequest: str = "50m"
+    cpuLimit: str = "100m"
+    memoryRequest: str = "64Mi"
+    memoryLimit: str = "128Mi"
+
+    # Ports
+    grpcPort: int = 50051
+    httpPort: int = 8080
+    grpcServicePort: int = 80
+    httpServicePort: int = 8080
+
+    # Config
+    loadConfigFrom: str = "cr"
+    configLocation: str = "clusterbook"
+    configName: str = "networks-labul"
+    serverPort: str = "50051"
+
+    # Service
+    serviceType: str = "ClusterIP"
+
+    # HTTPRoute (Gateway API)
+    httpRouteEnabled: bool = False
+    httpRouteParentRefName: str = ""
+    httpRouteParentRefNamespace: str = ""
+    httpRouteHostname: str = ""
+    httpRouteAnnotations: {str:str} = {}
+
+    # RBAC
+    networkConfigApiGroup: str = "github.stuttgart-things.com"
+
+    # Labels and annotations
+    labels: {str:str} = {}
+    annotations: {str:str} = {}
+
+    check:
+        replicas >= 0, "replicas must be >= 0"
+        grpcPort >= 1 and grpcPort <= 65535, "grpcPort must be valid"
+        httpPort >= 1 and httpPort <= 65535, "httpPort must be valid"
+        name != "", "name must not be empty"
+        namespace != "", "namespace must not be empty"

--- a/kcl/service.k
+++ b/kcl/service.k
@@ -1,0 +1,53 @@
+"""
+Services for clusterbook (gRPC + HTTP)
+"""
+
+import labels
+
+config = labels.config
+
+# gRPC service (primary, for programmatic access)
+serviceGrpc = {
+    apiVersion: "v1"
+    kind: "Service"
+    metadata: {
+        name: config.name
+        namespace: config.namespace
+        labels: labels.commonLabels
+    }
+    spec: {
+        type: config.serviceType
+        ports: [
+            {
+                name: "grpc"
+                port: config.grpcServicePort
+                targetPort: "grpc"
+                protocol: "TCP"
+            }
+        ]
+        selector: labels.selectorLabels
+    }
+}
+
+# HTTP service (for HTMX frontend and REST API)
+serviceHttp = {
+    apiVersion: "v1"
+    kind: "Service"
+    metadata: {
+        name: "{}-http".format(config.name)
+        namespace: config.namespace
+        labels: labels.commonLabels
+    }
+    spec: {
+        type: config.serviceType
+        ports: [
+            {
+                name: "http"
+                port: config.httpServicePort
+                targetPort: "http"
+                protocol: "TCP"
+            }
+        ]
+        selector: labels.selectorLabels
+    }
+}

--- a/kcl/serviceaccount.k
+++ b/kcl/serviceaccount.k
@@ -1,0 +1,17 @@
+"""
+ServiceAccount for clusterbook
+"""
+
+import labels
+
+config = labels.config
+
+serviceAccount = {
+    apiVersion: "v1"
+    kind: "ServiceAccount"
+    metadata: {
+        name: config.name
+        namespace: config.namespace
+        labels: labels.commonLabels
+    }
+}


### PR DESCRIPTION
## Summary
- Add KCL deployment manifests (replaces Helm for new deployments)
- Dual-port deployment: gRPC `:50051` + HTTP `:8080` (HTMX/REST)
- Conditional HTTPRoute (Gateway API) for web frontend exposure
- Updated README with features table, REST API docs, KCL deployment, config reference

## KCL Resources
| Resource | File | Description |
|----------|------|-------------|
| Namespace | namespace.k | clusterbook namespace |
| ServiceAccount | serviceaccount.k | Pod identity |
| ConfigMap | configmap.k | Env vars (LOAD_CONFIG_FROM, ports, etc.) |
| Role + RoleBinding | rbac.k | NetworkConfig CR access |
| Deployment | deploy.k | Dual-port container with security hardening |
| Service (gRPC) | service.k | ClusterIP on port 80 → 50051 |
| Service (HTTP) | service.k | ClusterIP on port 8080 → 8080 |
| HTTPRoute | httproute.k | Gateway API route (opt-in) |

## Test plan
- [x] `kcl run` renders all 8 resources correctly
- [x] `kcl run -D config.httpRouteEnabled=true ...` renders HTTPRoute
- [x] Schema validation works (port ranges, required fields)
- [x] README renders correctly with all sections

Closes #82

🤖 Generated with [Claude Code](https://claude.com/claude-code)