### PR TITLE
feat: TechDocs, Backstage catalog, and pages workflow

### DIFF
--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -1,0 +1,16 @@
+---
+name: Deploy Pages
+on:
+  workflow_dispatch:
+  workflow_run:
+    workflows: ["Release"]
+    types: [completed]
+
+jobs:
+  pages:
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event.workflow_run.conclusion == 'success'
+    uses: stuttgart-things/github-workflow-templates/.github/workflows/call-deploy-pages.yaml@main
+    with:
+      runs-on: ubuntu-latest

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: clusterbook
+  description: GitOps-based IP address management service for Kubernetes clusters with gRPC, REST API, and HTMX dashboard
+  annotations:
+    github.com/project-slug: stuttgart-things/clusterbook
+    backstage.io/techdocs-ref: url:https://github.com/stuttgart-things/clusterbook/tree/main
+    backstage.io/source-location: url:https://github.com/stuttgart-things/clusterbook
+  tags:
+    - ipam
+    - grpc
+    - golang
+    - kubernetes
+    - htmx
+  links:
+    - url: https://github.com/stuttgart-things/clusterbook
+      title: GitHub Repository
+      icon: github
+spec:
+  type: service
+  lifecycle: production
+  owner: platform-team
+  system: sthings

--- a/docs/cicd.md
+++ b/docs/cicd.md
@@ -1,0 +1,41 @@
+# CI/CD
+
+## GitHub Actions Workflows
+
+| Workflow | Trigger | Description |
+|----------|---------|-------------|
+| `build-scan-image` | Push to main, PRs | Build container image with ko, push to ghcr.io, scan with Trivy |
+| `release` | After image build | semantic-release: changelog, GitHub release, kustomize OCI push |
+| `pages` | After release | Deploy TechDocs to GitHub Pages |
+
+## Release Process
+
+Releases are fully automated via [semantic-release](https://semantic-release.gitbook.io/):
+
+- `fix:` commits trigger a **patch** bump
+- `feat:` commits trigger a **minor** bump
+- Each release publishes the container image and kustomize OCI artifact to `ghcr.io`
+
+## Workflow Chain
+
+```
+push to main → build-scan-image → release → pages
+                     │                │         │
+               ko build + push   semantic    techdocs
+               + trivy scan      release     deploy
+                                 + stage
+                                 image tag
+                                 + kustomize
+                                 OCI push
+```
+
+## Taskfile Commands
+
+```bash
+task build          # Build Go binary
+task build-ko       # Build, push, scan container image
+task test           # Run unit tests
+task lint           # Run Go linter
+task proto          # Generate Go code from proto
+task run            # Run locally
+```

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,61 @@
+# Deployment
+
+## Container Image
+
+Built with [ko](https://ko.build/) using a distroless base image (`cgr.dev/chainguard/static:latest`):
+
+```bash
+# Build locally
+ko build .
+
+# Build via Taskfile
+task build-ko
+```
+
+## KCL Deployment (recommended)
+
+Render and apply KCL manifests directly:
+
+```bash
+# Default deployment
+cd kcl && kcl run | kubectl apply -f -
+
+# Custom image version
+kcl run -D config.image=ghcr.io/stuttgart-things/clusterbook/clusterbook:v1.5.1 \
+  | kubectl apply -f -
+
+# With HTTPRoute (Gateway API)
+kcl run -D config.httpRouteEnabled=true \
+        -D config.httpRouteParentRefName=my-gateway \
+        -D config.httpRouteHostname=clusterbook.example.com \
+  | kubectl apply -f -
+```
+
+See the [KCL README](https://github.com/stuttgart-things/clusterbook/tree/main/kcl) for all profile parameters.
+
+## Rendered Resources
+
+| Resource | Name | Description |
+|----------|------|-------------|
+| Namespace | `clusterbook` | Dedicated namespace |
+| ServiceAccount | `clusterbook` | Pod identity |
+| ConfigMap | `clusterbook-config` | Environment configuration |
+| Role | `clusterbook` | NetworkConfig CR access |
+| RoleBinding | `clusterbook` | Binds SA to Role |
+| Deployment | `clusterbook` | Dual-port: gRPC + HTTP |
+| Service (gRPC) | `clusterbook` | ClusterIP on port 80 |
+| Service (HTTP) | `clusterbook-http` | ClusterIP on port 8080 |
+| HTTPRoute | `clusterbook` | Gateway API route (optional) |
+
+## Testing
+
+```bash
+# Unit tests
+go test ./...
+
+# Lint
+task lint
+
+# Build + scan image
+task build-ko
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,39 @@
+# clusterbook
+
+Go microservice for GitOps-based IP address management across Kubernetes clusters. Provides a gRPC API for programmatic access, a REST API for integrations, and an HTMX web dashboard for visualization.
+
+## Quick Start
+
+```bash
+# Run with disk backend
+LOAD_CONFIG_FROM=disk CONFIG_LOCATION=tests CONFIG_NAME=config.yaml go run .
+
+# Run with Kubernetes CR backend
+LOAD_CONFIG_FROM=cr CONFIG_LOCATION=clusterbook CONFIG_NAME=networks-labul go run .
+```
+
+## Architecture
+
+```
+                    ┌─────────────────────────┐
+                    │       clusterbook        │
+                    │                          │
+  gRPC :50051 ─────┤  internal/generate.go    │──── Kubernetes CR
+                    │  internal/load.go        │     (NetworkConfig)
+  REST :8080  ─────┤  internal/save.go        │
+                    │  internal/web.go         │──── Disk (YAML)
+  HTMX :8080  ─────┤  internal/transform.go   │
+                    └─────────────────────────┘
+```
+
+## Interfaces
+
+| Interface | Port | Description |
+|-----------|------|-------------|
+| gRPC | `:50051` | `GetIpAddressRange`, `SetClusterInfo` RPCs |
+| REST API | `:8080` | JSON endpoints for networks and IP management |
+| HTMX Dashboard | `:8080` | Web UI with pool visualization and inline assign/release |
+
+## Configuration
+
+All configuration is done via environment variables. See the main [README](https://github.com/stuttgart-things/clusterbook) for the full reference.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,8 @@
+site_name: Clusterbook
+site_description: GitOps cluster IP address management for Kubernetes
+nav:
+  - Home: index.md
+  - Deployment: deployment.md
+  - CI/CD: cicd.md
+plugins:
+  - techdocs-core


### PR DESCRIPTION
## Summary
- **docs/**: TechDocs pages (index, deployment, CI/CD)
- **mkdocs.yml**: TechDocs site config with techdocs-core plugin
- **catalog-info.yaml**: Backstage component (service, platform-team, sthings system)
- **pages.yaml**: Deploy TechDocs to GitHub Pages after release

## Files Added
| File | Description |
|------|-------------|
| `docs/index.md` | Overview, architecture diagram, interfaces table |
| `docs/deployment.md` | KCL deploy, container build, testing commands |
| `docs/cicd.md` | Workflow chain, release process, Taskfile commands |
| `mkdocs.yml` | MkDocs config for Backstage TechDocs |
| `catalog-info.yaml` | Backstage component definition |
| `.github/workflows/pages.yaml` | Pages deploy after release |

## Test plan
- [x] All markdown renders correctly
- [ ] Merge triggers image build → release → pages deploy chain

🤖 Generated with [Claude Code](https://claude.com/claude-code)