### PR TITLE
fix: add write permissions to release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,6 +7,12 @@ on:
     branches: [main]
   workflow_dispatch:
 
+permissions:
+  contents: write
+  packages: write
+  issues: write
+  pull-requests: write
+
 jobs:
   release:
     if: >-


### PR DESCRIPTION
## Summary
- Add explicit `permissions` block to release workflow granting `contents: write`, `packages: write`, `issues: write`, `pull-requests: write`
- Fixes semantic-release `EGITNOPERMISSION` error when pushing tags

## Test plan
- [ ] Merge and trigger release workflow (manual dispatch or via image build)
- [ ] Verify semantic-release can push tags and create GitHub release

🤖 Generated with [Claude Code](https://claude.com/claude-code)