### PR TITLE
fix: remove repositoryUrl from .releaserc

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -1,6 +1,5 @@
 {
   "branches": ["main"],
-  "repositoryUrl": "https://github.com/stuttgart-things/clusterbook",
   "tagFormat": "v${version}",
   "plugins": [
     [


### PR DESCRIPTION
## Summary
- Remove explicit `repositoryUrl` from `.releaserc`
- When set, semantic-release constructs its own auth URL bypassing the Dagger module's git remote rewrite (`https://x-access-token:$GITHUB_TOKEN@github.com/...`)
- This caused `EGITNOPERMISSION` / "Invalid username or token" errors
- Without it, semantic-release uses the git remote URL which Dagger already rewrites with proper token auth
- Matches the pattern used by homerun2-omni-pitcher (which has no `repositoryUrl` and works)

## Test plan
- [ ] Merge and verify release workflow succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)