### PR TITLE
fix: update container image path

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ cd kcl && kcl run
 ### Render with custom config
 
 ```bash
-kcl run -D config.image=ghcr.io/stuttgart-things/clusterbook/clusterbook:v1.5.1 \
+kcl run -D config.image=ghcr.io/stuttgart-things/clusterbook:v1.6.0 \
         -D config.namespace=clusterbook \
         -D config.configName=networks-labul
 ```

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -120,7 +120,7 @@ tasks:
         yq eval ".imageTag = \"$(echo ${BUILD_IMAGE} | awk -F':' '{print $2}')\"" -i {{ .PATH_HELM_ENV }}/{{ .K8S_ENV }}.yaml
     vars:
       META_PATH: '{{ .CHART_DIR }}/{{ .PROJECT_NAME }}/Chart.yaml'
-      RELEASE_IMAGE: ghcr.io/stuttgart-things/clusterbook/clusterbook
+      RELEASE_IMAGE: ghcr.io/stuttgart-things/clusterbook
       VERSION:
         sh: |
           [ "$(git branch --show-current)" != "main" ] && echo "$(git describe --tags --abbrev=0)-dev" || echo $(git describe --tags --abbrev=0)

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -21,7 +21,7 @@ Render and apply KCL manifests directly:
 cd kcl && kcl run | kubectl apply -f -
 
 # Custom image version
-kcl run -D config.image=ghcr.io/stuttgart-things/clusterbook/clusterbook:v1.5.1 \
+kcl run -D config.image=ghcr.io/stuttgart-things/clusterbook:v1.6.0 \
   | kubectl apply -f -
 
 # With HTTPRoute (Gateway API)

--- a/kcl/README.md
+++ b/kcl/README.md
@@ -16,7 +16,7 @@ dagger call -m github.com/stuttgart-things/dagger/kcl@v0.82.0 run \
 # render with inline parameters
 dagger call -m github.com/stuttgart-things/dagger/kcl@v0.82.0 run \
   --source kcl \
-  --parameters 'config.image=ghcr.io/stuttgart-things/clusterbook/clusterbook:v1.5.1,config.namespace=clusterbook' \
+  --parameters 'config.image=ghcr.io/stuttgart-things/clusterbook:v1.6.0,config.namespace=clusterbook' \
   export --path /tmp/rendered-clusterbook.yaml
 ```
 
@@ -24,7 +24,7 @@ dagger call -m github.com/stuttgart-things/dagger/kcl@v0.82.0 run \
 
 ```bash
 kcl run kcl/main.k \
-  -D 'config.image=ghcr.io/stuttgart-things/clusterbook/clusterbook:v1.5.1' \
+  -D 'config.image=ghcr.io/stuttgart-things/clusterbook:v1.6.0' \
   -D 'config.namespace=clusterbook'
 ```
 
@@ -35,7 +35,7 @@ kcl run kcl/main.k \
 cd kcl && kcl run | kubectl apply -f -
 
 # or with custom config
-kcl run -D 'config.image=ghcr.io/stuttgart-things/clusterbook/clusterbook:v1.5.1' \
+kcl run -D 'config.image=ghcr.io/stuttgart-things/clusterbook:v1.6.0' \
         -D 'config.configName=networks-labul' \
   | kubectl apply -f -
 ```
@@ -55,7 +55,7 @@ kcl run -D 'config.httpRouteEnabled=true' \
 |---|---|---|
 | `config.name` | `clusterbook` | Resource name |
 | `config.namespace` | `clusterbook` | Target namespace |
-| `config.image` | `ghcr.io/stuttgart-things/clusterbook/clusterbook:latest` | Container image |
+| `config.image` | `ghcr.io/stuttgart-things/clusterbook:v1.6.0` | Container image |
 | `config.imagePullPolicy` | `Always` | Image pull policy |
 | `config.replicas` | `1` | Replica count |
 | `config.grpcPort` | `50051` | gRPC container port |
@@ -86,7 +86,7 @@ kcl run -D 'config.httpRouteEnabled=true' \
 
 ```yaml
 ---
-config.image: ghcr.io/stuttgart-things/clusterbook/clusterbook:v1.5.1
+config.image: ghcr.io/stuttgart-things/clusterbook:v1.6.0
 config.namespace: clusterbook
 config.configName: networks-labul
 ```
@@ -95,7 +95,7 @@ config.configName: networks-labul
 
 ```yaml
 ---
-config.image: ghcr.io/stuttgart-things/clusterbook/clusterbook:v1.5.1
+config.image: ghcr.io/stuttgart-things/clusterbook:v1.6.0
 config.namespace: clusterbook-dev
 config.loadConfigFrom: disk
 config.configLocation: /config
@@ -106,7 +106,7 @@ config.configName: config.yaml
 
 ```yaml
 ---
-config.image: ghcr.io/stuttgart-things/clusterbook/clusterbook:v1.5.1
+config.image: ghcr.io/stuttgart-things/clusterbook:v1.6.0
 config.namespace: clusterbook
 config.configName: networks-labul
 config.httpRouteEnabled: true

--- a/kcl/schema.k
+++ b/kcl/schema.k
@@ -10,7 +10,7 @@ schema ClusterBook:
     namespace: str = "clusterbook"
 
     # Image
-    image: str = "ghcr.io/stuttgart-things/clusterbook/clusterbook:latest"
+    image: str = "ghcr.io/stuttgart-things/clusterbook:v1.6.0"
     imagePullPolicy: str = "Always"
 
     # Replicas and resources


### PR DESCRIPTION
## Summary
- Update image path from `ghcr.io/stuttgart-things/clusterbook/clusterbook` to `ghcr.io/stuttgart-things/clusterbook`
- The ko build workflow pushes to `ghcr.io/${{ github.repository }}` which is `ghcr.io/stuttgart-things/clusterbook`
- Updates KCL schema default, README, docs, Taskfile, and KCL README

## Test plan
- [x] Verified v1.6.0 deploys successfully with the correct image path on movie-scripts cluster

🤖 Generated with [Claude Code](https://claude.com/claude-code)