### PR TITLE
feat: add NetworkConfig CRD to KCL manifests

### DIFF
--- a/kcl/crd.k
+++ b/kcl/crd.k
@@ -1,0 +1,51 @@
+"""
+CustomResourceDefinition for NetworkConfig
+"""
+
+networkConfigCRD = {
+    apiVersion: "apiextensions.k8s.io/v1"
+    kind: "CustomResourceDefinition"
+    metadata: {
+        name: "networkconfigs.github.stuttgart-things.com"
+    }
+    spec: {
+        group: "github.stuttgart-things.com"
+        names: {
+            kind: "NetworkConfig"
+            plural: "networkconfigs"
+            singular: "networkconfig"
+            shortNames: ["nc"]
+        }
+        scope: "Namespaced"
+        versions: [
+            {
+                name: "v1"
+                served: True
+                storage: True
+                schema: {
+                    openAPIV3Schema: {
+                        type: "object"
+                        properties: {
+                            spec: {
+                                type: "object"
+                                properties: {
+                                    networks: {
+                                        type: "object"
+                                        additionalProperties: {
+                                            type: "array"
+                                            items: {
+                                                type: "string"
+                                            }
+                                        }
+                                        description: "Network pools keyed by subnet prefix, values are IP entries (e.g. '5:ASSIGNED:cluster-name')"
+                                    }
+                                }
+                                required: ["networks"]
+                            }
+                        }
+                    }
+                }
+            }
+        ]
+    }
+}

--- a/kcl/main.k
+++ b/kcl/main.k
@@ -4,6 +4,7 @@ Imports all resources and exports manifests
 """
 
 import manifests as k8s_manifests
+import crd
 import namespace
 import serviceaccount
 import configmap
@@ -15,6 +16,7 @@ import httproute
 # Export all manifests as a YAML stream (filter out None values)
 _manifests = [
     m for m in [
+        crd.networkConfigCRD
         namespace.namespace
         serviceaccount.serviceAccount
         configmap.configMap


### PR DESCRIPTION
## Summary
- Add `kcl/crd.k` with the NetworkConfig CRD (group: `github.stuttgart-things.com`, version: `v1`)
- Include CRD in `main.k` manifest list so it's rendered first in the YAML stream
- Follows the pattern from homerun2-scout (`kcl/crd.k`)
- Ensures clusters get the CRD automatically when deploying via kustomize OCI

## Test plan
- [x] `kcl run` renders the CRD as first document in YAML stream
- [ ] Release and verify CRD deploys to cluster

🤖 Generated with [Claude Code](https://claude.com/claude-code)