### PR TITLE
feat: integrate PowerDNS for automatic DNS management

### DIFF
--- a/internal/pdns.go
+++ b/internal/pdns.go
@@ -1,0 +1,154 @@
+/*
+Copyright © 2024 Patrick Hermann patrick.hermann@sva.de
+*/
+
+package internal
+
+import (
+	"bytes"
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"strings"
+)
+
+// PDNSClient manages PowerDNS API interactions
+type PDNSClient struct {
+	URL    string
+	Token  string
+	Zone   string
+	client *http.Client
+}
+
+// NewPDNSClient creates a new PowerDNS client from config.
+// Returns nil if PDNS is not enabled.
+func NewPDNSClient(enabled, url, token, zone string) *PDNSClient {
+	if enabled != "true" || url == "" || token == "" || zone == "" {
+		return nil
+	}
+
+	// Ensure zone ends with a dot (FQDN)
+	if !strings.HasSuffix(zone, ".") {
+		zone += "."
+	}
+
+	log.Printf("PDNS INTEGRATION ENABLED (zone: %s)", zone)
+	return &PDNSClient{
+		URL:   url,
+		Token: token,
+		Zone:  zone,
+		client: &http.Client{
+			Transport: &http.Transport{
+				TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, // #nosec G402 — matches Ansible role validate_certs: false
+			},
+		},
+	}
+}
+
+// rrset represents a PowerDNS RRSet for the PATCH API
+type rrset struct {
+	Name       string      `json:"name"`
+	Type       string      `json:"type"`
+	TTL        int         `json:"ttl"`
+	ChangeType string      `json:"changetype"`
+	Records    []pdRecord  `json:"records,omitempty"`
+	Comments   []pdComment `json:"comments,omitempty"`
+}
+
+type pdRecord struct {
+	Content  string `json:"content"`
+	Disabled bool   `json:"disabled"`
+}
+
+type pdComment struct {
+	Account string `json:"account"`
+	Content string `json:"content"`
+}
+
+type rrsetPayload struct {
+	RRSets []rrset `json:"rrsets"`
+}
+
+// CreateRecord creates a wildcard A record: *.{cluster}.{zone} → ip
+func (c *PDNSClient) CreateRecord(cluster, ip string) {
+	if c == nil || cluster == "" {
+		return
+	}
+
+	fqdn := fmt.Sprintf("*.%s.%s", cluster, c.Zone)
+
+	payload := rrsetPayload{
+		RRSets: []rrset{
+			{
+				Name:       fqdn,
+				Type:       "A",
+				TTL:        60,
+				ChangeType: "REPLACE",
+				Records:    []pdRecord{{Content: ip, Disabled: false}},
+				Comments:   []pdComment{{Account: "", Content: "managed by clusterbook"}},
+			},
+		},
+	}
+
+	c.patchZone(payload, "CREATE", fqdn, ip)
+}
+
+// DeleteRecord deletes the wildcard A record for a cluster
+func (c *PDNSClient) DeleteRecord(cluster string) {
+	if c == nil || cluster == "" {
+		return
+	}
+
+	fqdn := fmt.Sprintf("*.%s.%s", cluster, c.Zone)
+
+	payload := rrsetPayload{
+		RRSets: []rrset{
+			{
+				Name:       fqdn,
+				Type:       "A",
+				ChangeType: "DELETE",
+			},
+		},
+	}
+
+	c.patchZone(payload, "DELETE", fqdn, "")
+}
+
+// patchZone sends the PATCH request to PowerDNS
+func (c *PDNSClient) patchZone(payload rrsetPayload, action, fqdn, ip string) {
+	body, err := json.Marshal(payload)
+	if err != nil {
+		log.Printf("PDNS %s ERROR (marshal): %v", action, err)
+		return
+	}
+
+	url := fmt.Sprintf("%s/api/v1/servers/localhost/zones/%s", c.URL, c.Zone)
+	req, err := http.NewRequest(http.MethodPatch, url, bytes.NewReader(body))
+	if err != nil {
+		log.Printf("PDNS %s ERROR (request): %v", action, err)
+		return
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-API-Key", c.Token)
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		log.Printf("PDNS %s ERROR (http): %v", action, err)
+		return
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 300 {
+		log.Printf("PDNS %s FAILED: %s → HTTP %d", action, fqdn, resp.StatusCode)
+		return
+	}
+
+	if ip != "" {
+		log.Printf("PDNS %s OK: %s → %s", action, fqdn, ip)
+	} else {
+		log.Printf("PDNS %s OK: %s", action, fqdn)
+	}
+}

--- a/internal/web.go
+++ b/internal/web.go
@@ -32,7 +32,7 @@ type IPEntry struct {
 }
 
 // StartWebServer starts the HTTP server for HTMX frontend and REST API
-func StartWebServer(httpPort, loadFrom, configLoc, configNm string) {
+func StartWebServer(httpPort, loadFrom, configLoc, configNm string, pdns *PDNSClient) {
 	mux := http.NewServeMux()
 
 	// HTMX frontend routes
@@ -51,10 +51,10 @@ func StartWebServer(httpPort, loadFrom, configLoc, configNm string) {
 		handleAPINetworkIPs(w, r, loadFrom, configLoc, configNm)
 	})
 	mux.HandleFunc("POST /api/v1/networks/{key}/assign", func(w http.ResponseWriter, r *http.Request) {
-		handleAPIAssign(w, r, loadFrom, configLoc, configNm)
+		handleAPIAssign(w, r, loadFrom, configLoc, configNm, pdns)
 	})
 	mux.HandleFunc("POST /api/v1/networks/{key}/release", func(w http.ResponseWriter, r *http.Request) {
-		handleAPIRelease(w, r, loadFrom, configLoc, configNm)
+		handleAPIRelease(w, r, loadFrom, configLoc, configNm, pdns)
 	})
 
 	// REST API CRUD routes
@@ -73,10 +73,10 @@ func StartWebServer(httpPort, loadFrom, configLoc, configNm string) {
 
 	// HTMX partial routes
 	mux.HandleFunc("POST /htmx/assign", func(w http.ResponseWriter, r *http.Request) {
-		handleHTMXAssign(w, r, loadFrom, configLoc, configNm)
+		handleHTMXAssign(w, r, loadFrom, configLoc, configNm, pdns)
 	})
 	mux.HandleFunc("POST /htmx/release", func(w http.ResponseWriter, r *http.Request) {
-		handleHTMXRelease(w, r, loadFrom, configLoc, configNm)
+		handleHTMXRelease(w, r, loadFrom, configLoc, configNm, pdns)
 	})
 	mux.HandleFunc("POST /htmx/add-network", func(w http.ResponseWriter, r *http.Request) {
 		handleHTMXAddNetwork(w, r, loadFrom, configLoc, configNm)
@@ -176,7 +176,7 @@ func handleNetworkDetail(w http.ResponseWriter, r *http.Request, loadFrom, confi
 	}
 }
 
-func handleHTMXAssign(w http.ResponseWriter, r *http.Request, loadFrom, configLoc, configNm string) {
+func handleHTMXAssign(w http.ResponseWriter, r *http.Request, loadFrom, configLoc, configNm string, pdns *PDNSClient) {
 	if err := r.ParseForm(); err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
@@ -212,6 +212,7 @@ func handleHTMXAssign(w http.ResponseWriter, r *http.Request, loadFrom, configLo
 	ipList[ipKey][ipDigit] = entry
 
 	saveConfig(ipList, loadFrom, configLoc, configNm)
+	pdns.CreateRecord(cluster, ipKey+"."+ipDigit)
 
 	// Re-render the network detail table
 	ips := ipList[networkKey]
@@ -223,7 +224,7 @@ func handleHTMXAssign(w http.ResponseWriter, r *http.Request, loadFrom, configLo
 	}{networkKey, entries})
 }
 
-func handleHTMXRelease(w http.ResponseWriter, r *http.Request, loadFrom, configLoc, configNm string) {
+func handleHTMXRelease(w http.ResponseWriter, r *http.Request, loadFrom, configLoc, configNm string, pdns *PDNSClient) {
 	if err := r.ParseForm(); err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
@@ -247,11 +248,13 @@ func handleHTMXRelease(w http.ResponseWriter, r *http.Request, loadFrom, configL
 	}
 
 	entry := ipList[ipKey][ipDigit]
+	prevCluster := entry.Cluster
 	entry.Status = ""
 	entry.Cluster = ""
 	ipList[ipKey][ipDigit] = entry
 
 	saveConfig(ipList, loadFrom, configLoc, configNm)
+	pdns.DeleteRecord(prevCluster)
 
 	// Re-render the network detail table
 	ips := ipList[networkKey]
@@ -288,7 +291,7 @@ func handleAPINetworkIPs(w http.ResponseWriter, r *http.Request, loadFrom, confi
 	json.NewEncoder(w).Encode(entries)
 }
 
-func handleAPIAssign(w http.ResponseWriter, r *http.Request, loadFrom, configLoc, configNm string) {
+func handleAPIAssign(w http.ResponseWriter, r *http.Request, loadFrom, configLoc, configNm string, pdns *PDNSClient) {
 	networkKey := r.PathValue("key")
 
 	var req struct {
@@ -330,6 +333,7 @@ func handleAPIAssign(w http.ResponseWriter, r *http.Request, loadFrom, configLoc
 	ipList[networkKey][ipDigit] = entry
 
 	saveConfig(ipList, loadFrom, configLoc, configNm)
+	pdns.CreateRecord(req.Cluster, networkKey+"."+ipDigit)
 
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(map[string]string{
@@ -338,7 +342,7 @@ func handleAPIAssign(w http.ResponseWriter, r *http.Request, loadFrom, configLoc
 	})
 }
 
-func handleAPIRelease(w http.ResponseWriter, r *http.Request, loadFrom, configLoc, configNm string) {
+func handleAPIRelease(w http.ResponseWriter, r *http.Request, loadFrom, configLoc, configNm string, pdns *PDNSClient) {
 	networkKey := r.PathValue("key")
 
 	var req struct {
@@ -364,11 +368,13 @@ func handleAPIRelease(w http.ResponseWriter, r *http.Request, loadFrom, configLo
 	}
 
 	entry := ipList[networkKey][ipDigit]
+	prevCluster := entry.Cluster
 	entry.Status = ""
 	entry.Cluster = ""
 	ipList[networkKey][ipDigit] = entry
 
 	saveConfig(ipList, loadFrom, configLoc, configNm)
+	pdns.DeleteRecord(prevCluster)
 
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(map[string]string{

--- a/kcl/configmap.k
+++ b/kcl/configmap.k
@@ -20,5 +20,9 @@ configMap = {
         CONFIG_NAME: config.configName
         SERVER_PORT: config.serverPort
         HTTP_PORT: str(config.httpPort)
+        PDNS_ENABLED: str(config.pdnsEnabled).lower()
+        PDNS_URL: config.pdnsURL
+        PDNS_TOKEN: config.pdnsToken
+        PDNS_ZONE: config.pdnsZone
     }
 }

--- a/kcl/schema.k
+++ b/kcl/schema.k
@@ -42,6 +42,12 @@ schema ClusterBook:
     httpRouteHostname: str = ""
     httpRouteAnnotations: {str:str} = {}
 
+    # PowerDNS integration
+    pdnsEnabled: bool = False
+    pdnsURL: str = ""
+    pdnsToken: str = ""
+    pdnsZone: str = ""
+
     # RBAC
     networkConfigApiGroup: str = "github.stuttgart-things.com"
 

--- a/main.go
+++ b/main.go
@@ -35,6 +35,10 @@ var (
 	configLocation = os.Getenv("CONFIG_LOCATION")
 	serverPort     = os.Getenv("SERVER_PORT")
 	httpPort       = os.Getenv("HTTP_PORT")
+	pdnsEnabled    = os.Getenv("PDNS_ENABLED")
+	pdnsURL        = os.Getenv("PDNS_URL")
+	pdnsToken      = os.Getenv("PDNS_TOKEN")
+	pdnsZone       = os.Getenv("PDNS_ZONE")
 )
 
 func (s *server) GetIpAddressRange(ctx context.Context, req *ipservice.IpRequest) (*ipservice.IpResponse, error) {
@@ -139,8 +143,11 @@ func main() {
 		httpPort = webPort
 	}
 
+	// INIT PDNS CLIENT (nil if not enabled)
+	pdns := internal.NewPDNSClient(pdnsEnabled, pdnsURL, pdnsToken, pdnsZone)
+
 	// START HTTP/HTMX SERVER IN BACKGROUND
-	go internal.StartWebServer(httpPort, loadConfigFrom, configLocation, configName)
+	go internal.StartWebServer(httpPort, loadConfigFrom, configLocation, configName, pdns)
 
 	lis, err := net.Listen("tcp", serverPort)
 	if err != nil {


### PR DESCRIPTION
## Summary
- Add `PDNSClient` (`internal/pdns.go`) for PowerDNS API — creates wildcard A records on IP assign, deletes on release
- Wire PDNS into all assign/release handlers (HTMX + REST API)
- Add PDNS env vars (`PDNS_ENABLED`, `PDNS_URL`, `PDNS_TOKEN`, `PDNS_ZONE`) to main.go and KCL configmap/schema
- Replaces the Ansible playbook workflow for DNS record management

Closes #93

## Test plan
- [ ] Deploy with PDNS disabled — verify no DNS calls, existing behavior unchanged
- [ ] Deploy with PDNS enabled — assign IP, verify wildcard A record created in PowerDNS
- [ ] Release IP — verify DNS record deleted
- [ ] Test via REST API and HTMX dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)