### PR TITLE
feat: optional PowerDNS record creation per IP assignment

### DIFF
--- a/internal/web.go
+++ b/internal/web.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 	"sort"
 	"strconv"
+	"strings"
 )
 
 // NetworkPoolInfo holds summary info for a network pool
@@ -71,6 +72,14 @@ func StartWebServer(httpPort, loadFrom, configLoc, configNm string, pdns *PDNSCl
 		handleAPIDeleteIP(w, r, loadFrom, configLoc, configNm)
 	})
 
+	// Cluster info routes
+	mux.HandleFunc("GET /api/v1/clusters", func(w http.ResponseWriter, r *http.Request) {
+		handleAPIClusters(w, r, loadFrom, configLoc, configNm)
+	})
+	mux.HandleFunc("GET /api/v1/clusters/{name}", func(w http.ResponseWriter, r *http.Request) {
+		handleAPIClusterInfo(w, r, loadFrom, configLoc, configNm)
+	})
+
 	// HTMX partial routes
 	mux.HandleFunc("POST /htmx/assign", func(w http.ResponseWriter, r *http.Request) {
 		handleHTMXAssign(w, r, loadFrom, configLoc, configNm, pdns)
@@ -103,10 +112,10 @@ func getPoolInfos(ipList map[string]IPs) []NetworkPoolInfo {
 	for key, ips := range ipList {
 		info := NetworkPoolInfo{NetworkKey: key, Total: len(ips)}
 		for _, ipInfo := range ips {
-			switch ipInfo.Status {
-			case "ASSIGNED":
+			switch {
+			case strings.HasPrefix(ipInfo.Status, "ASSIGNED"):
 				info.Assigned++
-			case "PENDING":
+			case strings.HasPrefix(ipInfo.Status, "PENDING"):
 				info.Pending++
 			default:
 				info.Available++
@@ -170,7 +179,7 @@ func handleNetworkDetail(w http.ResponseWriter, r *http.Request, loadFrom, confi
 		Pools      []NetworkPoolInfo
 	}{networkKey, entries, pools}
 
-	tmpl := template.Must(template.New("network").Parse(networkDetailTemplate))
+	tmpl := template.Must(template.New("network").Funcs(TemplateFuncs()).Parse(networkDetailTemplate))
 	if err := tmpl.Execute(w, data); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 	}
@@ -186,6 +195,7 @@ func handleHTMXAssign(w http.ResponseWriter, r *http.Request, loadFrom, configLo
 	cluster := r.FormValue("cluster")
 	status := r.FormValue("status")
 	networkKey := r.FormValue("network_key")
+	createDNS := r.FormValue("create_dns") == "on"
 
 	if ip == "" || cluster == "" || status == "" {
 		http.Error(w, "Missing required fields", http.StatusBadRequest)
@@ -208,16 +218,22 @@ func handleHTMXAssign(w http.ResponseWriter, r *http.Request, loadFrom, configLo
 
 	entry := ipList[ipKey][ipDigit]
 	entry.Status = status
+	if createDNS {
+		entry.Status = status + ":DNS"
+	}
 	entry.Cluster = cluster
 	ipList[ipKey][ipDigit] = entry
 
 	saveConfig(ipList, loadFrom, configLoc, configNm)
-	pdns.CreateRecord(cluster, ipKey+"."+ipDigit)
+
+	if createDNS {
+		pdns.CreateRecord(cluster, ipKey+"."+ipDigit)
+	}
 
 	// Re-render the network detail table
 	ips := ipList[networkKey]
 	entries := getIPEntries(ips, networkKey)
-	tmpl := template.Must(template.New("table").Parse(ipTablePartial))
+	tmpl := template.Must(template.New("table").Funcs(TemplateFuncs()).Parse(ipTablePartial))
 	tmpl.Execute(w, struct {
 		NetworkKey string
 		Entries    []IPEntry
@@ -249,17 +265,21 @@ func handleHTMXRelease(w http.ResponseWriter, r *http.Request, loadFrom, configL
 
 	entry := ipList[ipKey][ipDigit]
 	prevCluster := entry.Cluster
+	hadDNS := strings.HasSuffix(entry.Status, ":DNS")
 	entry.Status = ""
 	entry.Cluster = ""
 	ipList[ipKey][ipDigit] = entry
 
 	saveConfig(ipList, loadFrom, configLoc, configNm)
-	pdns.DeleteRecord(prevCluster)
+
+	if hadDNS {
+		pdns.DeleteRecord(prevCluster)
+	}
 
 	// Re-render the network detail table
 	ips := ipList[networkKey]
 	entries := getIPEntries(ips, networkKey)
-	tmpl := template.Must(template.New("table").Parse(ipTablePartial))
+	tmpl := template.Must(template.New("table").Funcs(TemplateFuncs()).Parse(ipTablePartial))
 	tmpl.Execute(w, struct {
 		NetworkKey string
 		Entries    []IPEntry
@@ -295,9 +315,10 @@ func handleAPIAssign(w http.ResponseWriter, r *http.Request, loadFrom, configLoc
 	networkKey := r.PathValue("key")
 
 	var req struct {
-		IP      string `json:"ip"`
-		Cluster string `json:"cluster"`
-		Status  string `json:"status"`
+		IP        string `json:"ip"`
+		Cluster   string `json:"cluster"`
+		Status    string `json:"status"`
+		CreateDNS bool   `json:"create_dns"`
 	}
 
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
@@ -329,11 +350,17 @@ func handleAPIAssign(w http.ResponseWriter, r *http.Request, loadFrom, configLoc
 
 	entry := ipList[networkKey][ipDigit]
 	entry.Status = req.Status
+	if req.CreateDNS {
+		entry.Status = req.Status + ":DNS"
+	}
 	entry.Cluster = req.Cluster
 	ipList[networkKey][ipDigit] = entry
 
 	saveConfig(ipList, loadFrom, configLoc, configNm)
-	pdns.CreateRecord(req.Cluster, networkKey+"."+ipDigit)
+
+	if req.CreateDNS {
+		pdns.CreateRecord(req.Cluster, networkKey+"."+ipDigit)
+	}
 
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(map[string]string{
@@ -369,12 +396,16 @@ func handleAPIRelease(w http.ResponseWriter, r *http.Request, loadFrom, configLo
 
 	entry := ipList[networkKey][ipDigit]
 	prevCluster := entry.Cluster
+	hadDNS := strings.HasSuffix(entry.Status, ":DNS")
 	entry.Status = ""
 	entry.Cluster = ""
 	ipList[networkKey][ipDigit] = entry
 
 	saveConfig(ipList, loadFrom, configLoc, configNm)
-	pdns.DeleteRecord(prevCluster)
+
+	if hadDNS {
+		pdns.DeleteRecord(prevCluster)
+	}
 
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(map[string]string{
@@ -511,6 +542,73 @@ func handleAPIDeleteIP(w http.ResponseWriter, r *http.Request, loadFrom, configL
 	})
 }
 
+// --- Cluster Info Handlers ---
+
+func handleAPIClusters(w http.ResponseWriter, r *http.Request, loadFrom, configLoc, configNm string) {
+	ipList := LoadProfile(loadFrom, configLoc, configNm)
+
+	clusters := map[string][]map[string]string{}
+	for networkKey, ips := range ipList {
+		for ipDigit, entry := range ips {
+			if entry.Cluster != "" {
+				clusters[entry.Cluster] = append(clusters[entry.Cluster], map[string]string{
+					"network": networkKey,
+					"ip":      networkKey + "." + ipDigit,
+					"status":  entry.Status,
+				})
+			}
+		}
+	}
+
+	type clusterSummary struct {
+		Cluster string `json:"cluster"`
+		IPCount int    `json:"ip_count"`
+	}
+
+	result := []clusterSummary{}
+	for name, ips := range clusters {
+		result = append(result, clusterSummary{Cluster: name, IPCount: len(ips)})
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(result)
+}
+
+func handleAPIClusterInfo(w http.ResponseWriter, r *http.Request, loadFrom, configLoc, configNm string) {
+	clusterName := r.PathValue("name")
+	ipList := LoadProfile(loadFrom, configLoc, configNm)
+
+	type ipInfo struct {
+		Network string `json:"network"`
+		IP      string `json:"ip"`
+		Status  string `json:"status"`
+	}
+
+	var ips []ipInfo
+	for networkKey, network := range ipList {
+		for ipDigit, entry := range network {
+			if entry.Cluster == clusterName {
+				ips = append(ips, ipInfo{
+					Network: networkKey,
+					IP:      networkKey + "." + ipDigit,
+					Status:  entry.Status,
+				})
+			}
+		}
+	}
+
+	if len(ips) == 0 {
+		http.Error(w, `{"error":"cluster not found"}`, http.StatusNotFound)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]interface{}{
+		"cluster": clusterName,
+		"ips":     ips,
+	})
+}
+
 // --- HTMX CRUD Handlers ---
 
 func handleHTMXAddNetwork(w http.ResponseWriter, r *http.Request, loadFrom, configLoc, configNm string) {
@@ -589,7 +687,7 @@ func handleHTMXAddIP(w http.ResponseWriter, r *http.Request, loadFrom, configLoc
 
 	// Re-render the IP table
 	entries := getIPEntries(ipList[networkKey], networkKey)
-	tmpl := template.Must(template.New("table").Parse(ipTablePartial))
+	tmpl := template.Must(template.New("table").Funcs(TemplateFuncs()).Parse(ipTablePartial))
 	tmpl.Execute(w, struct {
 		NetworkKey string
 		Entries    []IPEntry
@@ -623,7 +721,7 @@ func handleHTMXDeleteIP(w http.ResponseWriter, r *http.Request, loadFrom, config
 
 	// Re-render the IP table
 	entries := getIPEntries(ipList[networkKey], networkKey)
-	tmpl := template.Must(template.New("table").Parse(ipTablePartial))
+	tmpl := template.Must(template.New("table").Funcs(TemplateFuncs()).Parse(ipTablePartial))
 	tmpl.Execute(w, struct {
 		NetworkKey string
 		Entries    []IPEntry
@@ -856,15 +954,15 @@ const ipTablePartial = `<table>
         <tr>
             <td style="font-family: monospace;">{{.IP}}</td>
             <td>
-                {{if eq .Status "ASSIGNED"}}<span class="badge badge-assigned">ASSIGNED</span>
-                {{else if eq .Status "PENDING"}}<span class="badge badge-pending">PENDING</span>
+                {{if hasPrefix .Status "ASSIGNED"}}<span class="badge badge-assigned">ASSIGNED</span>{{if hasSuffix .Status ":DNS"}} <span class="badge" style="background: #1e3a5f; color: #60a5fa; font-size: 0.65rem;">DNS</span>{{end}}
+                {{else if hasPrefix .Status "PENDING"}}<span class="badge badge-pending">PENDING</span>{{if hasSuffix .Status ":DNS"}} <span class="badge" style="background: #1e3a5f; color: #60a5fa; font-size: 0.65rem;">DNS</span>{{end}}
                 {{else}}<span class="badge badge-available">AVAILABLE</span>
                 {{end}}
             </td>
             <td>{{if .Cluster}}{{.Cluster}}{{else}}<span style="color: #475569;">—</span>{{end}}</td>
             <td>
                 <div style="display: flex; gap: 0.5rem; align-items: center;">
-                {{if or (eq .Status "ASSIGNED") (eq .Status "PENDING")}}
+                {{if or (hasPrefix .Status "ASSIGNED") (hasPrefix .Status "PENDING")}}
                 <form class="form-inline" hx-post="/htmx/release" hx-target="#ip-table" hx-swap="innerHTML">
                     <input type="hidden" name="ip" value="{{.IP}}">
                     <input type="hidden" name="network_key" value="{{$.NetworkKey}}">
@@ -879,6 +977,7 @@ const ipTablePartial = `<table>
                         <option value="ASSIGNED">ASSIGNED</option>
                         <option value="PENDING">PENDING</option>
                     </select>
+                    <label style="display: flex; align-items: center; gap: 0.25rem; font-size: 0.75rem; color: #94a3b8; cursor: pointer;"><input type="checkbox" name="create_dns" style="accent-color: #6366f1;"> DNS</label>
                     <button type="submit" class="btn btn-assign">Assign</button>
                 </form>
                 {{end}}
@@ -912,5 +1011,7 @@ func TemplateFuncs() template.FuncMap {
 		"mul": func(a float64, b float64) float64 {
 			return a * b
 		},
+		"hasPrefix": strings.HasPrefix,
+		"hasSuffix": strings.HasSuffix,
 	}
 }

--- a/kcl/README.md
+++ b/kcl/README.md
@@ -1,6 +1,6 @@
 # clusterbook / KCL Deployment
 
-KCL-based Kubernetes manifests for clusterbook. Renders Namespace, ServiceAccount, ConfigMap, Role/RoleBinding, Deployment (dual-port: gRPC + HTTP), Services, and optional HTTPRoute (Gateway API).
+KCL-based Kubernetes manifests for clusterbook. Renders Namespace, ServiceAccount, ConfigMap, Secret (for PDNS credentials), Role/RoleBinding, Deployment (dual-port: gRPC + HTTP), Services, and optional HTTPRoute (Gateway API).
 
 ## Render Manifests
 
@@ -16,7 +16,7 @@ dagger call -m github.com/stuttgart-things/dagger/kcl@v0.82.0 run \
 # render with inline parameters
 dagger call -m github.com/stuttgart-things/dagger/kcl@v0.82.0 run \
   --source kcl \
-  --parameters 'config.image=ghcr.io/stuttgart-things/clusterbook:v1.6.0,config.namespace=clusterbook' \
+  --parameters 'config.image=ghcr.io/stuttgart-things/clusterbook:v1.11.0,config.namespace=clusterbook' \
   export --path /tmp/rendered-clusterbook.yaml
 ```
 
@@ -24,7 +24,7 @@ dagger call -m github.com/stuttgart-things/dagger/kcl@v0.82.0 run \
 
 ```bash
 kcl run kcl/main.k \
-  -D 'config.image=ghcr.io/stuttgart-things/clusterbook:v1.6.0' \
+  -D 'config.image=ghcr.io/stuttgart-things/clusterbook:v1.11.0' \
   -D 'config.namespace=clusterbook'
 ```
 
@@ -35,7 +35,7 @@ kcl run kcl/main.k \
 cd kcl && kcl run | kubectl apply -f -
 
 # or with custom config
-kcl run -D 'config.image=ghcr.io/stuttgart-things/clusterbook:v1.6.0' \
+kcl run -D 'config.image=ghcr.io/stuttgart-things/clusterbook:v1.11.0' \
         -D 'config.configName=networks-labul' \
   | kubectl apply -f -
 ```
@@ -55,7 +55,7 @@ kcl run -D 'config.httpRouteEnabled=true' \
 |---|---|---|
 | `config.name` | `clusterbook` | Resource name |
 | `config.namespace` | `clusterbook` | Target namespace |
-| `config.image` | `ghcr.io/stuttgart-things/clusterbook:v1.6.0` | Container image |
+| `config.image` | `ghcr.io/stuttgart-things/clusterbook:v1.11.0` | Container image |
 | `config.imagePullPolicy` | `Always` | Image pull policy |
 | `config.replicas` | `1` | Replica count |
 | `config.grpcPort` | `50051` | gRPC container port |
@@ -73,6 +73,10 @@ kcl run -D 'config.httpRouteEnabled=true' \
 | `config.httpRouteParentRefNamespace` | *(empty)* | Gateway namespace |
 | `config.httpRouteHostname` | *(empty)* | Hostname for HTTPRoute |
 | `config.httpRouteAnnotations` | `{}` | Extra annotations for HTTPRoute |
+| `config.pdnsEnabled` | `false` | Enable PowerDNS integration |
+| `config.pdnsURL` | *(empty)* | PowerDNS API base URL |
+| `config.pdnsToken` | *(empty)* | PowerDNS API key (stored in Secret) |
+| `config.pdnsZone` | *(empty)* | PowerDNS DNS zone |
 | `config.cpuRequest` | `50m` | CPU request |
 | `config.cpuLimit` | `100m` | CPU limit |
 | `config.memoryRequest` | `64Mi` | Memory request |
@@ -86,7 +90,7 @@ kcl run -D 'config.httpRouteEnabled=true' \
 
 ```yaml
 ---
-config.image: ghcr.io/stuttgart-things/clusterbook:v1.6.0
+config.image: ghcr.io/stuttgart-things/clusterbook:v1.11.0
 config.namespace: clusterbook
 config.configName: networks-labul
 ```
@@ -95,7 +99,7 @@ config.configName: networks-labul
 
 ```yaml
 ---
-config.image: ghcr.io/stuttgart-things/clusterbook:v1.6.0
+config.image: ghcr.io/stuttgart-things/clusterbook:v1.11.0
 config.namespace: clusterbook-dev
 config.loadConfigFrom: disk
 config.configLocation: /config
@@ -106,13 +110,26 @@ config.configName: config.yaml
 
 ```yaml
 ---
-config.image: ghcr.io/stuttgart-things/clusterbook:v1.6.0
+config.image: ghcr.io/stuttgart-things/clusterbook:v1.11.0
 config.namespace: clusterbook
 config.configName: networks-labul
 config.httpRouteEnabled: true
 config.httpRouteParentRefName: sthings-gateway
 config.httpRouteParentRefNamespace: ingress-system
 config.httpRouteHostname: clusterbook.sthings-vsphere.labul.sva.de
+```
+
+### With PowerDNS integration
+
+```yaml
+---
+config.image: ghcr.io/stuttgart-things/clusterbook:v1.11.0
+config.namespace: clusterbook
+config.configName: networks-labul
+config.pdnsEnabled: true
+config.pdnsURL: https://pdns.sthings-vsphere.labul.sva.de
+config.pdnsToken: my-api-key
+config.pdnsZone: sthings.io
 ```
 
 ## Rendered Resources
@@ -127,4 +144,5 @@ config.httpRouteHostname: clusterbook.sthings-vsphere.labul.sva.de
 | Deployment | `{name}` | Always |
 | Service (gRPC) | `{name}` | Always |
 | Service (HTTP) | `{name}-http` | Always |
+| Secret | `{name}-pdns` | Only if `pdnsEnabled=true` |
 | HTTPRoute | `{name}` | Only if `httpRouteEnabled=true` |

--- a/kcl/configmap.k
+++ b/kcl/configmap.k
@@ -22,7 +22,6 @@ configMap = {
         HTTP_PORT: str(config.httpPort)
         PDNS_ENABLED: str(config.pdnsEnabled).lower()
         PDNS_URL: config.pdnsURL
-        PDNS_TOKEN: config.pdnsToken
         PDNS_ZONE: config.pdnsZone
     }
 }

--- a/kcl/deploy.k
+++ b/kcl/deploy.k
@@ -55,7 +55,13 @@ deployment = {
                                     name: "{}-config".format(config.name)
                                 }
                             }
-                        ]
+                        ] + ([
+                            {
+                                secretRef: {
+                                    name: "{}-pdns".format(config.name)
+                                }
+                            }
+                        ] if config.pdnsEnabled else [])
                         resources: {
                             requests: {
                                 cpu: config.cpuRequest

--- a/kcl/labels.k
+++ b/kcl/labels.k
@@ -16,6 +16,10 @@ _httpRouteParentRefName = option("config.httpRouteParentRefName")
 _httpRouteParentRefNamespace = option("config.httpRouteParentRefNamespace")
 _httpRouteHostname = option("config.httpRouteHostname")
 _httpRouteAnnotations = option("config.httpRouteAnnotations") or {}
+_pdnsEnabled = option("config.pdnsEnabled")
+_pdnsURL = option("config.pdnsURL")
+_pdnsToken = option("config.pdnsToken")
+_pdnsZone = option("config.pdnsZone")
 
 # Config instance with command-line overrides
 config: schema.ClusterBook = schema.ClusterBook {
@@ -41,6 +45,14 @@ config: schema.ClusterBook = schema.ClusterBook {
         httpRouteHostname = _httpRouteHostname
     if _httpRouteAnnotations:
         httpRouteAnnotations = _httpRouteAnnotations
+    if _pdnsEnabled:
+        pdnsEnabled = _pdnsEnabled in [True, "True", "true"]
+    if _pdnsURL:
+        pdnsURL = _pdnsURL
+    if _pdnsToken:
+        pdnsToken = _pdnsToken
+    if _pdnsZone:
+        pdnsZone = _pdnsZone
 }
 
 # Common labels applied to all resources

--- a/kcl/main.k
+++ b/kcl/main.k
@@ -8,6 +8,7 @@ import crd
 import namespace
 import serviceaccount
 import configmap
+import secret
 import deploy
 import service
 import rbac
@@ -20,6 +21,7 @@ _manifests = [
         namespace.namespace
         serviceaccount.serviceAccount
         configmap.configMap
+        secret.pdnsSecret
         rbac.role
         rbac.roleBinding
         deploy.deployment

--- a/kcl/schema.k
+++ b/kcl/schema.k
@@ -10,7 +10,7 @@ schema ClusterBook:
     namespace: str = "clusterbook"
 
     # Image
-    image: str = "ghcr.io/stuttgart-things/clusterbook:v1.10.0"
+    image: str = "ghcr.io/stuttgart-things/clusterbook:v1.11.0"
     imagePullPolicy: str = "Always"
 
     # Replicas and resources

--- a/kcl/secret.k
+++ b/kcl/secret.k
@@ -1,0 +1,21 @@
+"""
+Secret for clusterbook PowerDNS credentials
+"""
+
+import labels
+
+config = labels.config
+
+pdnsSecret = {
+    apiVersion: "v1"
+    kind: "Secret"
+    metadata: {
+        name: "{}-pdns".format(config.name)
+        namespace: config.namespace
+        labels: labels.commonLabels
+    }
+    type: "Opaque"
+    stringData: {
+        PDNS_TOKEN: config.pdnsToken
+    }
+} if config.pdnsEnabled else None


### PR DESCRIPTION
## Summary

- Add `create_dns` flag to REST API assign endpoint and DNS checkbox to HTMX UI, so DNS records are only created when explicitly opted-in (not on every assign)
- Move `PDNS_TOKEN` from ConfigMap to Kubernetes Secret for security
- Track DNS state via status suffix (`:DNS`) — release handler only deletes DNS records for IPs that were assigned with DNS
- Bump default clusterbook image to `v1.11.0` in KCL schema
- Update KCL README with PowerDNS parameters, example profile, and Secret in rendered resources table

## API Changes

**REST API assign** (`POST /api/v1/networks/{key}/assign`):
```json
{"ip": "5", "cluster": "my-cluster", "status": "ASSIGNED", "create_dns": true}
```
`create_dns` defaults to `false` — backward compatible, existing callers won't create DNS records.

**HTMX UI**: New "DNS" checkbox in the assign form row.

**Status encoding**: `ASSIGNED` (no DNS) vs `ASSIGNED:DNS` (DNS record created). Release auto-detects and only calls `DeleteRecord` for `:DNS` entries.

## Test plan

- [ ] Build passes (`go build ./...`)
- [ ] Tests pass (`go test ./...`)
- [ ] KCL renders correctly with and without `pdnsEnabled`
- [ ] Verify HTMX UI shows DNS checkbox and DNS badge on assigned IPs
- [ ] Verify REST API respects `create_dns` flag
- [ ] Verify release only deletes DNS for `:DNS` entries

Closes #100

🤖 Generated with [Claude Code](https://claude.com/claude-code)