### PR TITLE
feat: add CIDR-aware IP allocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,12 @@ gitops cluster configuration management
 | Feature | Description |
 |---------|-------------|
 | IP Address Management | Allocate and track IPs across Kubernetes clusters |
+| CIDR-aware Allocation | Define pools as CIDR ranges (e.g. `10.31.103.0/24`) with auto-expansion |
 | gRPC API | Programmatic access on port `:50051` |
 | REST API | JSON endpoints on port `:8080` |
 | HTMX Dashboard | Web UI for IP pool visualization and management |
 | Dual Storage | Filesystem (YAML) or Kubernetes CRD backend |
+| PowerDNS Integration | Optional DNS record management for IP assignments |
 | KCL Manifests | Type-safe Kubernetes deployment with KCL |
 
 ## DEPLOYMENT
@@ -53,6 +55,32 @@ kcl run -D config.httpRouteEnabled=true \
 
 ```bash
 cd kcl && kcl run | kubectl apply -f -
+```
+
+</details>
+
+## LOCAL DEVELOPMENT
+
+<details><summary>RUN LOCALLY</summary>
+
+### From disk config (easiest)
+
+```bash
+LOAD_CONFIG_FROM=disk CONFIG_LOCATION=tests CONFIG_NAME=config.yaml go run .
+```
+
+### From Kubernetes CR (requires cluster access)
+
+```bash
+LOAD_CONFIG_FROM=cr CONFIG_LOCATION=clusterbook CONFIG_NAME=networks-labul go run .
+```
+
+### Using Taskfile + .env
+
+Create a `.env` file (see [example below](#example-env-file)), then:
+
+```bash
+task run
 ```
 
 </details>
@@ -98,6 +126,33 @@ curl -X POST http://localhost:8080/api/v1/networks/10.31.103/release \
   -d '{"ip": "10.31.103.6"}'
 ```
 
+### Create a network from CIDR
+
+```bash
+# Creates a /24 pool with 252 usable IPs (excludes .0, .1, .2, .255)
+curl -X POST http://localhost:8080/api/v1/networks/cidr \
+  -H "Content-Type: application/json" \
+  -d '{"cidr": "10.31.105.0/24", "reserved": ["1", "2"]}'
+```
+
+The existing `POST /api/v1/networks` endpoint also accepts CIDR:
+
+```bash
+curl -X POST http://localhost:8080/api/v1/networks \
+  -H "Content-Type: application/json" \
+  -d '{"cidr": "10.31.105.0/28"}'
+```
+
+CIDR ranges spanning multiple /24 blocks (e.g. `/23`) automatically create multiple network entries.
+
+### Assign an IP with DNS
+
+```bash
+curl -X POST http://localhost:8080/api/v1/networks/10.31.103/assign \
+  -H "Content-Type: application/json" \
+  -d '{"ip": "10.31.103.6", "cluster": "my-cluster", "status": "ASSIGNED", "create_dns": true}'
+```
+
 </details>
 
 <details><summary>gRPC</summary>
@@ -110,6 +165,30 @@ grpcurl -plaintext localhost:50051 ipservice.IpService/GetIpAddressRange \
 # Assign IPs to a cluster
 grpcurl -plaintext localhost:50051 ipservice.IpService/SetClusterInfo \
   -d '{"ipAddressRange": "10.31.103.6", "clusterName": "my-cluster", "status": "ASSIGNED"}'
+```
+
+</details>
+
+<details><summary>DAGGER MODULE</summary>
+
+A [Dagger](https://dagger.io) module is available at [stuttgart-things/dagger/clusterbook](https://github.com/stuttgart-things/dagger) for pipeline integration.
+
+```bash
+# List all networks
+dagger call list-networks --server="clusterbook.example.com:8080"
+
+# Create network from CIDR
+dagger call create-network-from-cidr --server="localhost:8080" --cidr="10.31.105.0/24" --reserved="1"
+
+# Assign IP with DNS
+dagger call assign-ip --server="localhost:8080" --network-key="10.31.103" \
+  --ip="10.31.103.6" --cluster="my-cluster" --status="ASSIGNED" --create-dns
+
+# Release IP
+dagger call release-ip --server="localhost:8080" --network-key="10.31.103" --ip="10.31.103.6"
+
+# List clusters
+dagger call list-clusters --server="localhost:8080"
 ```
 
 </details>
@@ -193,6 +272,10 @@ EOF
 | `SERVER_PORT` | gRPC server port | `50051` |
 | `HTTP_PORT` | HTTP/HTMX server port | `8080` |
 | `KUBECONFIG` | K8s config path (for CR backend) | - |
+| `PDNS_ENABLED` | Enable PowerDNS integration | `false` |
+| `PDNS_URL` | PowerDNS API URL | - |
+| `PDNS_TOKEN` | PowerDNS API token | - |
+| `PDNS_ZONE` | PowerDNS zone for records | - |
 
 ## DEV TASKS
 

--- a/internal/cidr.go
+++ b/internal/cidr.go
@@ -1,0 +1,168 @@
+/*
+Copyright © 2024 Patrick Hermann patrick.hermann@sva.de
+*/
+
+package internal
+
+import (
+	"encoding/binary"
+	"fmt"
+	"net"
+	"strconv"
+	"strings"
+)
+
+// CIDRToNetworks parses a CIDR notation string and returns a map of network prefix keys
+// (first 3 octets) to slices of last-octet strings. Network and broadcast addresses
+// are automatically excluded. Additional IPs can be excluded via the reserved parameter
+// (as last-octet strings, e.g. "1" for the gateway).
+func CIDRToNetworks(cidr string, reserved []string) (map[string][]string, error) {
+	ip, ipNet, err := net.ParseCIDR(cidr)
+	if err != nil {
+		return nil, fmt.Errorf("invalid CIDR notation: %w", err)
+	}
+
+	ip4 := ip.To4()
+	if ip4 == nil {
+		return nil, fmt.Errorf("only IPv4 CIDR is supported")
+	}
+
+	// Build reserved set for quick lookup (keyed by full IP string)
+	reservedSet := make(map[string]bool)
+	for _, r := range reserved {
+		reservedSet[r] = true
+	}
+
+	// Calculate network and broadcast addresses
+	maskLen, _ := ipNet.Mask.Size()
+	networkIP := ipNet.IP.To4()
+	networkInt := binary.BigEndian.Uint32(networkIP)
+	hostBits := uint(32 - maskLen)
+
+	// For /31 and /32, no broadcast/network exclusion per RFC 3021
+	excludeNetBroadcast := hostBits > 1
+	var broadcastInt uint32
+	if excludeNetBroadcast {
+		broadcastInt = networkInt | (0xFFFFFFFF >> uint(maskLen))
+	}
+
+	result := make(map[string][]string)
+
+	// Iterate through all IPs in the CIDR range
+	for current := networkInt; ipNet.Contains(uint32ToIP(current)); current++ {
+		// Skip network address
+		if excludeNetBroadcast && current == networkInt {
+			continue
+		}
+		// Skip broadcast address
+		if excludeNetBroadcast && current == broadcastInt {
+			continue
+		}
+
+		currentIP := uint32ToIP(current)
+		octets := strings.Split(currentIP.String(), ".")
+		if len(octets) != 4 {
+			continue
+		}
+
+		networkKey := strings.Join(octets[:3], ".")
+		lastOctet := octets[3]
+
+		// Skip reserved IPs
+		if reservedSet[lastOctet] {
+			continue
+		}
+
+		result[networkKey] = append(result[networkKey], lastOctet)
+	}
+
+	if len(result) == 0 {
+		return nil, fmt.Errorf("CIDR %s produced no usable IPs", cidr)
+	}
+
+	return result, nil
+}
+
+// ValidateCIDR checks if a string is valid CIDR notation
+func ValidateCIDR(cidr string) error {
+	_, _, err := net.ParseCIDR(cidr)
+	if err != nil {
+		return fmt.Errorf("invalid CIDR notation: %w", err)
+	}
+
+	ip, _, _ := net.ParseCIDR(cidr)
+	if ip.To4() == nil {
+		return fmt.Errorf("only IPv4 CIDR is supported")
+	}
+
+	return nil
+}
+
+// CIDRToIPList returns all usable host IPs in a CIDR range as full IP address strings
+func CIDRToIPList(cidr string, reserved []string) ([]string, error) {
+	networks, err := CIDRToNetworks(cidr, reserved)
+	if err != nil {
+		return nil, err
+	}
+
+	var ips []string
+	// Sort network keys for deterministic output
+	keys := sortedKeys(networks)
+	for _, key := range keys {
+		for _, octet := range networks[key] {
+			ips = append(ips, key+"."+octet)
+		}
+	}
+
+	return ips, nil
+}
+
+// CIDRNetworkKey returns the 3-octet network prefix for a /24 or smaller CIDR
+func CIDRNetworkKey(cidr string) (string, error) {
+	ip, _, err := net.ParseCIDR(cidr)
+	if err != nil {
+		return "", fmt.Errorf("invalid CIDR notation: %w", err)
+	}
+
+	ip4 := ip.To4()
+	if ip4 == nil {
+		return "", fmt.Errorf("only IPv4 CIDR is supported")
+	}
+
+	return fmt.Sprintf("%d.%d.%d", ip4[0], ip4[1], ip4[2]), nil
+}
+
+func uint32ToIP(n uint32) net.IP {
+	ip := make(net.IP, 4)
+	binary.BigEndian.PutUint32(ip, n)
+	return ip
+}
+
+func sortedKeys(m map[string][]string) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	// Sort by parsing octets numerically
+	for i := 0; i < len(keys); i++ {
+		for j := i + 1; j < len(keys); j++ {
+			if compareNetworkKeys(keys[i], keys[j]) > 0 {
+				keys[i], keys[j] = keys[j], keys[i]
+			}
+		}
+	}
+	return keys
+}
+
+func compareNetworkKeys(a, b string) int {
+	aParts := strings.Split(a, ".")
+	bParts := strings.Split(b, ".")
+	for i := 0; i < 3 && i < len(aParts) && i < len(bParts); i++ {
+		aNum, _ := strconv.Atoi(aParts[i])
+		bNum, _ := strconv.Atoi(bParts[i])
+		if aNum != bNum {
+			return aNum - bNum
+		}
+	}
+	return 0
+}

--- a/internal/cidr_test.go
+++ b/internal/cidr_test.go
@@ -1,0 +1,139 @@
+/*
+Copyright © 2024 Patrick Hermann patrick.hermann@sva.de
+*/
+
+package internal
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCIDRToNetworks_Slash24(t *testing.T) {
+	networks, err := CIDRToNetworks("10.31.103.0/24", nil)
+	require.NoError(t, err)
+
+	assert.Len(t, networks, 1)
+	assert.Contains(t, networks, "10.31.103")
+
+	ips := networks["10.31.103"]
+	// /24 = 256 addresses, minus network (.0) and broadcast (.255) = 254 usable
+	assert.Len(t, ips, 254)
+
+	// Verify .0 and .255 are excluded
+	assert.NotContains(t, ips, "0")
+	assert.NotContains(t, ips, "255")
+
+	// Verify .1 and .254 are included
+	assert.Contains(t, ips, "1")
+	assert.Contains(t, ips, "254")
+}
+
+func TestCIDRToNetworks_Slash28(t *testing.T) {
+	networks, err := CIDRToNetworks("10.31.103.0/28", nil)
+	require.NoError(t, err)
+
+	assert.Len(t, networks, 1)
+	ips := networks["10.31.103"]
+	// /28 = 16 addresses, minus network (.0) and broadcast (.15) = 14 usable
+	assert.Len(t, ips, 14)
+	assert.Contains(t, ips, "1")
+	assert.Contains(t, ips, "14")
+	assert.NotContains(t, ips, "0")
+	assert.NotContains(t, ips, "15")
+}
+
+func TestCIDRToNetworks_Slash30(t *testing.T) {
+	networks, err := CIDRToNetworks("10.31.103.0/30", nil)
+	require.NoError(t, err)
+
+	ips := networks["10.31.103"]
+	// /30 = 4 addresses, minus network and broadcast = 2 usable
+	assert.Len(t, ips, 2)
+	assert.Contains(t, ips, "1")
+	assert.Contains(t, ips, "2")
+}
+
+func TestCIDRToNetworks_WithReserved(t *testing.T) {
+	reserved := []string{"1", "2"}
+	networks, err := CIDRToNetworks("10.31.103.0/24", reserved)
+	require.NoError(t, err)
+
+	ips := networks["10.31.103"]
+	// 254 usable minus 2 reserved = 252
+	assert.Len(t, ips, 252)
+	assert.NotContains(t, ips, "1")
+	assert.NotContains(t, ips, "2")
+	assert.Contains(t, ips, "3")
+}
+
+func TestCIDRToNetworks_CrossSlash24Boundary(t *testing.T) {
+	networks, err := CIDRToNetworks("10.31.103.0/23", nil)
+	require.NoError(t, err)
+
+	// /23 spans two /24 blocks
+	assert.Len(t, networks, 2)
+	assert.Contains(t, networks, "10.31.102")
+	assert.Contains(t, networks, "10.31.103")
+
+	// First block: 10.31.102.1-254 (network is 10.31.102.0, broadcast is 10.31.103.255)
+	// All 255 addresses in 10.31.102 except .0 (network address) = 255
+	assert.Len(t, networks["10.31.102"], 255)
+	// Second block: all 255 except .255 (broadcast)
+	assert.Len(t, networks["10.31.103"], 255)
+}
+
+func TestCIDRToNetworks_InvalidCIDR(t *testing.T) {
+	_, err := CIDRToNetworks("not-a-cidr", nil)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid CIDR")
+}
+
+func TestCIDRToNetworks_IPv6Rejected(t *testing.T) {
+	_, err := CIDRToNetworks("::1/128", nil)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "IPv4")
+}
+
+func TestCIDRToNetworks_NonZeroHost(t *testing.T) {
+	// CIDR with non-zero host bits - net.ParseCIDR normalizes to network address
+	networks, err := CIDRToNetworks("10.31.103.50/28", nil)
+	require.NoError(t, err)
+
+	ips := networks["10.31.103"]
+	// 10.31.103.50/28 -> network is 10.31.103.48, broadcast is 10.31.103.63
+	// Usable: 49-62 = 14 hosts
+	assert.Len(t, ips, 14)
+	assert.Contains(t, ips, "49")
+	assert.Contains(t, ips, "62")
+	assert.NotContains(t, ips, "48")
+	assert.NotContains(t, ips, "63")
+}
+
+func TestCIDRToIPList(t *testing.T) {
+	ips, err := CIDRToIPList("10.31.103.0/30", nil)
+	require.NoError(t, err)
+
+	assert.Len(t, ips, 2)
+	assert.Contains(t, ips, "10.31.103.1")
+	assert.Contains(t, ips, "10.31.103.2")
+}
+
+func TestValidateCIDR(t *testing.T) {
+	assert.NoError(t, ValidateCIDR("10.0.0.0/8"))
+	assert.NoError(t, ValidateCIDR("192.168.1.0/24"))
+	assert.Error(t, ValidateCIDR("invalid"))
+	assert.Error(t, ValidateCIDR("::1/128"))
+}
+
+func TestCIDRNetworkKey(t *testing.T) {
+	key, err := CIDRNetworkKey("10.31.103.0/24")
+	require.NoError(t, err)
+	assert.Equal(t, "10.31.103", key)
+
+	key, err = CIDRNetworkKey("192.168.1.0/24")
+	require.NoError(t, err)
+	assert.Equal(t, "192.168.1", key)
+}

--- a/internal/web.go
+++ b/internal/web.go
@@ -62,6 +62,9 @@ func StartWebServer(httpPort, loadFrom, configLoc, configNm string, pdns *PDNSCl
 	mux.HandleFunc("POST /api/v1/networks", func(w http.ResponseWriter, r *http.Request) {
 		handleAPICreateNetwork(w, r, loadFrom, configLoc, configNm)
 	})
+	mux.HandleFunc("POST /api/v1/networks/cidr", func(w http.ResponseWriter, r *http.Request) {
+		handleAPICreateNetworkFromCIDR(w, r, loadFrom, configLoc, configNm)
+	})
 	mux.HandleFunc("DELETE /api/v1/networks/{key}", func(w http.ResponseWriter, r *http.Request) {
 		handleAPIDeleteNetwork(w, r, loadFrom, configLoc, configNm)
 	})
@@ -426,8 +429,10 @@ func handleAPIRelease(w http.ResponseWriter, r *http.Request, loadFrom, configLo
 
 func handleAPICreateNetwork(w http.ResponseWriter, r *http.Request, loadFrom, configLoc, configNm string) {
 	var req struct {
-		Network string   `json:"network"`
-		IPs     []string `json:"ips"`
+		Network  string   `json:"network"`
+		IPs      []string `json:"ips"`
+		CIDR     string   `json:"cidr"`
+		Reserved []string `json:"reserved"`
 	}
 
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
@@ -435,12 +440,51 @@ func handleAPICreateNetwork(w http.ResponseWriter, r *http.Request, loadFrom, co
 		return
 	}
 
-	if req.Network == "" || len(req.IPs) == 0 {
-		http.Error(w, `{"error":"network and ips are required"}`, http.StatusBadRequest)
+	ipList := LoadProfile(loadFrom, configLoc, configNm)
+
+	// CIDR mode: expand CIDR notation into networks
+	if req.CIDR != "" {
+		networks, err := CIDRToNetworks(req.CIDR, req.Reserved)
+		if err != nil {
+			http.Error(w, fmt.Sprintf(`{"error":"%s"}`, err.Error()), http.StatusBadRequest)
+			return
+		}
+
+		createdKeys := []string{}
+		totalIPs := 0
+
+		for networkKey, octets := range networks {
+			if _, exists := ipList[networkKey]; exists {
+				http.Error(w, fmt.Sprintf(`{"error":"network %s already exists"}`, networkKey), http.StatusConflict)
+				return
+			}
+
+			ipList[networkKey] = make(IPs)
+			for _, octet := range octets {
+				ipList[networkKey][octet] = IPInfo{}
+			}
+
+			createdKeys = append(createdKeys, networkKey)
+			totalIPs += len(octets)
+		}
+
+		saveConfig(ipList, loadFrom, configLoc, configNm)
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"status":   "ok",
+			"message":  fmt.Sprintf("Created %d network(s) with %d IPs from CIDR %s", len(createdKeys), totalIPs, req.CIDR),
+			"networks": createdKeys,
+		})
 		return
 	}
 
-	ipList := LoadProfile(loadFrom, configLoc, configNm)
+	// Flat list mode: existing behavior
+	if req.Network == "" || len(req.IPs) == 0 {
+		http.Error(w, `{"error":"network and ips are required, or provide cidr"}`, http.StatusBadRequest)
+		return
+	}
 
 	if _, exists := ipList[req.Network]; exists {
 		http.Error(w, `{"error":"network already exists"}`, http.StatusConflict)
@@ -459,6 +503,59 @@ func handleAPICreateNetwork(w http.ResponseWriter, r *http.Request, loadFrom, co
 	json.NewEncoder(w).Encode(map[string]string{
 		"status":  "ok",
 		"message": fmt.Sprintf("Network %s created with %d IPs", req.Network, len(req.IPs)),
+	})
+}
+
+func handleAPICreateNetworkFromCIDR(w http.ResponseWriter, r *http.Request, loadFrom, configLoc, configNm string) {
+	var req struct {
+		CIDR     string   `json:"cidr"`
+		Reserved []string `json:"reserved"`
+	}
+
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, `{"error":"invalid request body"}`, http.StatusBadRequest)
+		return
+	}
+
+	if req.CIDR == "" {
+		http.Error(w, `{"error":"cidr is required"}`, http.StatusBadRequest)
+		return
+	}
+
+	networks, err := CIDRToNetworks(req.CIDR, req.Reserved)
+	if err != nil {
+		http.Error(w, fmt.Sprintf(`{"error":"%s"}`, err.Error()), http.StatusBadRequest)
+		return
+	}
+
+	ipList := LoadProfile(loadFrom, configLoc, configNm)
+
+	createdKeys := []string{}
+	totalIPs := 0
+
+	for networkKey, octets := range networks {
+		if _, exists := ipList[networkKey]; exists {
+			http.Error(w, fmt.Sprintf(`{"error":"network %s already exists"}`, networkKey), http.StatusConflict)
+			return
+		}
+
+		ipList[networkKey] = make(IPs)
+		for _, octet := range octets {
+			ipList[networkKey][octet] = IPInfo{}
+		}
+
+		createdKeys = append(createdKeys, networkKey)
+		totalIPs += len(octets)
+	}
+
+	saveConfig(ipList, loadFrom, configLoc, configNm)
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusCreated)
+	json.NewEncoder(w).Encode(map[string]interface{}{
+		"status":   "ok",
+		"message":  fmt.Sprintf("Created %d network(s) with %d IPs from CIDR %s", len(createdKeys), totalIPs, req.CIDR),
+		"networks": createdKeys,
 	})
 }
 


### PR DESCRIPTION
## Summary
- Add CIDR notation support for defining network pools (e.g. `10.31.103.0/24`) instead of enumerating individual IPs
- New dedicated `POST /api/v1/networks/cidr` endpoint and optional `cidr` field on existing create endpoint
- Auto-excludes network/broadcast addresses, supports reserved IP exclusion (gateway etc.)
- CIDRs spanning multiple /24 blocks (e.g. `/23`) automatically create multiple network entries
- Updated README with CIDR examples, DNS assignment docs, PDNS config, and Dagger module usage

## Test plan
- [x] Unit tests for CIDR parsing: /24, /28, /30, cross-boundary /23, reserved IPs, IPv6 rejection
- [ ] Integration test: create network via CIDR endpoint, verify IPs are allocatable
- [ ] Verify backward compatibility: existing flat-list create still works

Closes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)