### PR TITLE
fix: set go-version to 1.26.0 in CI workflow

### DIFF
--- a/.github/workflows/build-scan-image.yaml
+++ b/.github/workflows/build-scan-image.yaml
@@ -18,4 +18,5 @@ jobs:
     uses: stuttgart-things/github-workflow-templates/.github/workflows/call-ko-build.yaml@main
     with:
       runs-on: ubuntu-latest
+      go-version: "1.26.0"
     secrets: inherit # pragma: allowlist secret


### PR DESCRIPTION
## Summary
- Passes `go-version: "1.26.0"` to the reusable ko-build workflow
- Fixes build failures caused by `go.mod` requiring Go 1.26.0 while the workflow defaults to 1.25.5

## Test plan
- [x] CI should pass on this PR itself

🤖 Generated with [Claude Code](https://claude.com/claude-code)