### PR TITLE
fix: set go-version to 1.26.0 in release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,6 +21,7 @@ jobs:
     uses: stuttgart-things/github-workflow-templates/.github/workflows/call-go-release.yaml@main
     with:
       runs-on: ubuntu-latest
+      go-version: "1.26.0"
       stage-image: true
       push-kustomize: true
       kcl-source-dir: kcl


### PR DESCRIPTION
## Summary
- Passes `go-version: "1.26.0"` to the reusable go-release workflow
- Fixes goreleaser failing with `go.mod requires go >= 1.26.0 (running go 1.25.5; GOTOOLCHAIN=local)`

## Test plan
- [x] Release workflow should succeed after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)