### PR TITLE
feat: add run-web task and improve footer with project link

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,18 @@ Create a `.env` file (see [example below](#example-env-file)), then:
 task run
 ```
 
+### Quick web UI start (no .env needed)
+
+```bash
+task run-web
+```
+
+This runs the web UI with disk config from `tests/config.yaml` on port `8080`. Override defaults with:
+
+```bash
+task run-web CONFIG_LOCATION=mydir CONFIG_NAME=myconfig.yaml HTTP_PORT=9090
+```
+
 </details>
 
 ## USAGE

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -71,6 +71,20 @@ tasks:
     cmds:
       - "$GOPATH/bin/{{ .PROJECT_NAME }}"
 
+  run-web:
+    desc: Run web UI with disk config (local dev)
+    vars:
+      CONFIG_LOCATION: '{{ .CONFIG_LOCATION | default "tests" }}'
+      CONFIG_NAME: '{{ .CONFIG_NAME | default "config.yaml" }}'
+      HTTP_PORT: '{{ .HTTP_PORT | default "8080" }}'
+    env:
+      LOAD_CONFIG_FROM: disk
+      CONFIG_LOCATION: "{{ .CONFIG_LOCATION }}"
+      CONFIG_NAME: "{{ .CONFIG_NAME }}"
+      HTTP_PORT: "{{ .HTTP_PORT }}"
+    cmds:
+      - go run .
+
   build-client:
     desc: Build client
     deps: [proto]

--- a/internal/web.go
+++ b/internal/web.go
@@ -13,7 +13,6 @@ import (
 	"sort"
 	"strconv"
 	"strings"
-	"time"
 )
 
 // NetworkPoolInfo holds summary info for a network pool
@@ -172,7 +171,6 @@ type dashboardData struct {
 	StartTime string
 }
 
-var serverStartTime = time.Now().Format(time.RFC3339)
 
 func handleDashboard(w http.ResponseWriter, r *http.Request, loadFrom, configLoc, configNm string) {
 	ipList := LoadProfile(loadFrom, configLoc, configNm)
@@ -182,7 +180,7 @@ func handleDashboard(w http.ResponseWriter, r *http.Request, loadFrom, configLoc
 		Pools:     pools,
 		Version:   version,
 		Commit:    commit,
-		StartTime: serverStartTime,
+		StartTime: date,
 	}
 
 	tmpl := template.Must(template.New("dashboard").Funcs(TemplateFuncs()).Parse(dashboardTemplate))
@@ -1204,7 +1202,8 @@ const dashboardTemplate = `<!DOCTYPE html>
         <div class="footer">
             <div class="footer-item"><span class="footer-label">version</span> <span class="footer-value">{{.Version}}</span></div>
             <div class="footer-item"><span class="footer-label">commit</span> <span class="footer-value">{{if gt (len .Commit) 7}}{{slice .Commit 0 7}}{{else}}{{.Commit}}{{end}}</span></div>
-            <div class="footer-item"><span class="footer-label">deployed</span> <span class="footer-value">{{.StartTime}}</span></div>
+            <div class="footer-item"><span class="footer-label">built</span> <span class="footer-value">{{.StartTime}}</span></div>
+            <div class="footer-item" style="margin-left:auto"><span class="footer-label">a</span> <a href="https://github.com/stuttgart-things" target="_blank" style="color:#818cf8;text-decoration:none">stuttgart-things</a> <span class="footer-label">project</span> <img src="https://raw.githubusercontent.com/stuttgart-things/docs/main/hugo/sthings-logo.png" alt="sthings" style="height:24px;vertical-align:middle"></div>
         </div>
     </div>
 </body>


### PR DESCRIPTION
## Summary
- Add `run-web` Taskfile task for quick local web UI development (disk config, no `.env` needed)
- Change footer label from "deployed" to "built", using build-time `date` variable instead of runtime start time
- Add "a stuttgart-things project" link with logo to the dashboard footer (matching homerun2-core-catcher style)
- Update README with `task run-web` usage and override examples

## Test plan
- [x] `go test ./...` passes
- [ ] `task run-web` starts web UI on port 8080
- [ ] Footer shows "built" label with build date
- [ ] Footer shows stuttgart-things project link with logo

🤖 Generated with [Claude Code](https://claude.com/claude-code)