### PR TITLE
fix: handle DNS status suffix in CR format deserialization

### DIFF
--- a/internal/transform.go
+++ b/internal/transform.go
@@ -66,7 +66,14 @@ func ConvertFromCRFormat(data map[string][]string) map[string]IPs {
 			if len(parts) > 1 {
 				info.Status = parts[1]
 				if len(parts) > 2 {
-					info.Cluster = parts[2]
+					// Handle status suffix like "ASSIGNED:DNS" where DNS is part of the status
+					// CR format: "digit:STATUS:DNS:cluster" (4 parts) or "digit:STATUS:cluster" (3 parts)
+					if len(parts) == 4 {
+						info.Status = parts[1] + ":" + parts[2]
+						info.Cluster = parts[3]
+					} else {
+						info.Cluster = parts[2]
+					}
 				}
 			}
 

--- a/internal/transform_test.go
+++ b/internal/transform_test.go
@@ -119,7 +119,7 @@ func TestTruncateIP(t *testing.T) {
 
 // TestConvertFromCRFormat tests the ConvertFromCRFormat function
 func TestConvertFromCRFormat(t *testing.T) {
-	// Input data in CR format
+	// Input data in CR format, including DNS suffix case
 	data := map[string][]string{
 		"10.31.103": {
 			"3:assigned:sandiego",
@@ -129,6 +129,10 @@ func TestConvertFromCRFormat(t *testing.T) {
 		"10.31.104": {
 			"4:pending:losangeles",
 			"5",
+		},
+		"10.31.102": {
+			"2:ASSIGNED:DNS:sthings-infra",
+			"3",
 		},
 	}
 
@@ -141,6 +145,10 @@ func TestConvertFromCRFormat(t *testing.T) {
 		"10.31.104": {
 			"4": {Status: "pending", Cluster: "losangeles"},
 			"5": {Status: "", Cluster: ""},
+		},
+		"10.31.102": {
+			"2": {Status: "ASSIGNED:DNS", Cluster: "sthings-infra"},
+			"3": {Status: "", Cluster: ""},
 		},
 	}
 

--- a/internal/web.go
+++ b/internal/web.go
@@ -1324,7 +1324,7 @@ const ipTablePartial = `<table>
                         <option value="ASSIGNED" {{if hasPrefix .Status "ASSIGNED"}}selected{{end}}>ASSIGNED</option>
                         <option value="PENDING" {{if hasPrefix .Status "PENDING"}}selected{{end}}>PENDING</option>
                     </select>
-                    <label style="display: flex; align-items: center; gap: 0.25rem; font-size: 0.75rem; color: #94a3b8; cursor: pointer;"><input type="checkbox" name="create_dns" {{if hasSuffix .Status ":DNS"}}checked{{end}} style="accent-color: #6366f1;"> DNS</label>
+                    <label style="display: flex; align-items: center; gap: 0.15rem; font-size: 0.75rem; color: #94a3b8; cursor: pointer; white-space: nowrap;"><input type="checkbox" name="create_dns" {{if hasSuffix .Status ":DNS"}}checked{{end}} style="accent-color: #6366f1; margin-right: 0.15rem;"> DNS</label>
                     <button type="submit" class="btn btn-assign">Save</button>
                 </form>
                 <form class="form-inline" hx-post="/htmx/release" hx-target="#ip-table" hx-swap="innerHTML">
@@ -1341,7 +1341,7 @@ const ipTablePartial = `<table>
                         <option value="ASSIGNED">ASSIGNED</option>
                         <option value="PENDING">PENDING</option>
                     </select>
-                    <label style="display: flex; align-items: center; gap: 0.25rem; font-size: 0.75rem; color: #94a3b8; cursor: pointer;"><input type="checkbox" name="create_dns" style="accent-color: #6366f1;"> DNS</label>
+                    <label style="display: flex; align-items: center; gap: 0.15rem; font-size: 0.75rem; color: #94a3b8; cursor: pointer; white-space: nowrap;"><input type="checkbox" name="create_dns" style="accent-color: #6366f1; margin-right: 0.15rem;"> DNS</label>
                     <button type="submit" class="btn btn-assign">Assign</button>
                 </form>
                 {{end}}


### PR DESCRIPTION
## Summary
- Fix `ConvertFromCRFormat` to correctly parse 4-part CR entries (`digit:ASSIGNED:DNS:cluster`) where the `:DNS` suffix is part of the status, not the cluster name
- Add test case for DNS suffix roundtrip in `TestConvertFromCRFormat`
- Tighten DNS checkbox label spacing in HTMX UI for better visual coupling

## Root Cause
When `handleAPIReserve` sets status to `ASSIGNED:DNS`, the CR format serializes as `2:ASSIGNED:DNS:sthings-infra`. `ConvertFromCRFormat` split by `:` and used `parts[2]` ("DNS") as cluster instead of `parts[3]` ("sthings-infra").

## Test plan
- [ ] `go test ./internal/ -run TestConvert -v` passes
- [ ] Reserve an IP with `create_dns: true` via API, verify cluster name persists correctly after reload
- [ ] Check DNS checkbox alignment in UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)