### PR TITLE
fix: show wildcard FQDN in DNS test result

### DIFF
--- a/internal/pdns.go
+++ b/internal/pdns.go
@@ -118,27 +118,28 @@ func (c *PDNSClient) DeleteRecord(cluster string) {
 }
 
 // TestDNS resolves test.{cluster}.{zone} and checks if it matches the expected IP.
-// Returns (resolvedIP, match, error).
-func (c *PDNSClient) TestDNS(cluster, expectedIP string) (string, bool, error) {
+// Returns (fqdn, resolvedIP, match, error).
+func (c *PDNSClient) TestDNS(cluster, expectedIP string) (string, string, bool, error) {
 	if c == nil {
-		return "", false, fmt.Errorf("PDNS not enabled")
+		return "", "", false, fmt.Errorf("PDNS not enabled")
 	}
 
 	zone := strings.TrimSuffix(c.Zone, ".")
-	fqdn := fmt.Sprintf("test.%s.%s", cluster, zone)
+	fqdn := fmt.Sprintf("*.%s.%s", cluster, zone)
+	lookupHost := fmt.Sprintf("test.%s.%s", cluster, zone)
 
-	ips, err := net.LookupHost(fqdn)
+	ips, err := net.LookupHost(lookupHost)
 	if err != nil {
-		return "", false, fmt.Errorf("lookup %s: %w", fqdn, err)
+		return fqdn, "", false, fmt.Errorf("lookup %s: %w", lookupHost, err)
 	}
 
 	for _, ip := range ips {
 		if ip == expectedIP {
-			return ip, true, nil
+			return fqdn, ip, true, nil
 		}
 	}
 
-	return strings.Join(ips, ","), false, nil
+	return fqdn, strings.Join(ips, ","), false, nil
 }
 
 // patchZone sends the PATCH request to PowerDNS

--- a/internal/web.go
+++ b/internal/web.go
@@ -1082,16 +1082,16 @@ func handleHTMXTestDNS(w http.ResponseWriter, r *http.Request, pdns *PDNSClient)
 		return
 	}
 
-	resolved, match, err := pdns.TestDNS(cluster, expectedIP)
+	fqdn, resolved, match, err := pdns.TestDNS(cluster, expectedIP)
 	if err != nil {
 		fmt.Fprintf(w, `<span style="color:#ef4444;font-size:0.75rem;" title="%s">DNS FAIL</span>`, err.Error())
 		return
 	}
 
 	if match {
-		fmt.Fprintf(w, `<span style="color:#4ade80;font-size:0.75rem;">DNS OK (%s)</span>`, resolved)
+		fmt.Fprintf(w, `<span style="color:#4ade80;font-size:0.75rem;">%s → %s</span>`, fqdn, resolved)
 	} else {
-		fmt.Fprintf(w, `<span style="color:#ef4444;font-size:0.75rem;">MISMATCH: got %s</span>`, resolved)
+		fmt.Fprintf(w, `<span style="color:#ef4444;font-size:0.75rem;">%s → %s (expected %s)</span>`, fqdn, resolved, expectedIP)
 	}
 }
 


### PR DESCRIPTION
## Summary
- DNS test button now shows `*.sthings-infra.sthings-vsphere.labul.sva.de → 10.31.102.2` instead of just `DNS OK (10.31.102.2)`
- On mismatch shows the FQDN, resolved IP, and expected IP

## Test plan
- [ ] Click DNS test button, verify output shows full `*.{cluster}.{zone} → {ip}` format

🤖 Generated with [Claude Code](https://claude.com/claude-code)