### PR TITLE
feat: add DD-WRT support to KCL deployment and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ gitops cluster configuration management
 | HTMX Dashboard | Web UI for IP pool visualization and management |
 | Dual Storage | Filesystem (YAML) or Kubernetes CRD backend |
 | PowerDNS Integration | Optional DNS record management for IP assignments |
+| DD-WRT Integration | Optional DNS via DD-WRT router (SSH + dnsmasq) |
 | KCL Manifests | Type-safe Kubernetes deployment with KCL |
 
 ## DEPLOYMENT
@@ -288,6 +289,66 @@ EOF
 | `PDNS_URL` | PowerDNS API URL | - |
 | `PDNS_TOKEN` | PowerDNS API token | - |
 | `PDNS_ZONE` | PowerDNS zone for records | - |
+| `DDWRT_ENABLED` | Enable DD-WRT DNS integration | `false` |
+| `DDWRT_HOST` | DD-WRT router IP/hostname | - |
+| `DDWRT_USER` | SSH user for DD-WRT | - |
+| `DDWRT_PASSWORD` | SSH password for DD-WRT | - |
+| `DDWRT_ZONE` | DNS zone (e.g. `sthings.lab`) | - |
+
+## DNS PROVIDERS
+
+Both DNS providers are optional and can run simultaneously. Enable them via env vars. Records are created/deleted when `create_dns: true` is passed during assign/release.
+
+<details><summary>POWERDNS</summary>
+
+Creates wildcard A records (`*.cluster.zone`) via the PowerDNS REST API.
+
+```bash
+PDNS_ENABLED=true
+PDNS_URL=http://pdns.sthings.lab:8081
+PDNS_TOKEN=your-api-key
+PDNS_ZONE=sthings.lab.
+```
+
+</details>
+
+<details><summary>DD-WRT</summary>
+
+Manages `dnsmasq` address entries on a DD-WRT router via SSH + `nvram`. Creates entries like `address=/cluster.zone/ip`.
+
+```bash
+DDWRT_ENABLED=true
+DDWRT_HOST=192.168.1.1
+DDWRT_USER=root
+DDWRT_PASSWORD=your-router-password
+DDWRT_ZONE=sthings.lab
+```
+
+**Credential handling in Kubernetes:**
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: clusterbook-ddwrt
+type: Opaque
+stringData:
+  DDWRT_ENABLED: "true"
+  DDWRT_HOST: "192.168.1.1"
+  DDWRT_USER: "root"
+  DDWRT_PASSWORD: "your-router-password"
+  DDWRT_ZONE: "sthings.lab"
+```
+
+Reference in the deployment:
+
+```yaml
+envFrom:
+  - secretRef:
+      name: clusterbook-ddwrt
+```
+
+</details>
 
 ## DEV TASKS
 
@@ -327,6 +388,13 @@ CONFIG_NAME=networks-labul #resource-name
 
 SERVER_PORT=50051
 HTTP_PORT=8080
+
+# DD-WRT DNS (optional)
+#DDWRT_ENABLED=true
+#DDWRT_HOST=192.168.1.1
+#DDWRT_USER=root
+#DDWRT_PASSWORD=secret
+#DDWRT_ZONE=sthings.lab
 
 #CLUSTERBOOK_SERVER=localhost:50051
 #SECURE_CONNECTION=false

--- a/kcl/README.md
+++ b/kcl/README.md
@@ -1,6 +1,6 @@
 # clusterbook / KCL Deployment
 
-KCL-based Kubernetes manifests for clusterbook. Renders Namespace, ServiceAccount, ConfigMap, Secret (for PDNS credentials), Role/RoleBinding, Deployment (dual-port: gRPC + HTTP), Services, and optional HTTPRoute (Gateway API).
+KCL-based Kubernetes manifests for clusterbook. Renders Namespace, ServiceAccount, ConfigMap, Secrets (for PDNS/DD-WRT credentials), Role/RoleBinding, Deployment (dual-port: gRPC + HTTP), Services, and optional HTTPRoute (Gateway API).
 
 ## Render Manifests
 
@@ -77,6 +77,11 @@ kcl run -D 'config.httpRouteEnabled=true' \
 | `config.pdnsURL` | *(empty)* | PowerDNS API base URL |
 | `config.pdnsToken` | *(empty)* | PowerDNS API key (stored in Secret) |
 | `config.pdnsZone` | *(empty)* | PowerDNS DNS zone |
+| `config.ddwrtEnabled` | `false` | Enable DD-WRT DNS integration |
+| `config.ddwrtHost` | *(empty)* | DD-WRT router IP/hostname |
+| `config.ddwrtUser` | *(empty)* | SSH user for DD-WRT |
+| `config.ddwrtPassword` | *(empty)* | SSH password (stored in Secret) |
+| `config.ddwrtZone` | *(empty)* | DNS zone (e.g. `sthings.lab`) |
 | `config.cpuRequest` | `50m` | CPU request |
 | `config.cpuLimit` | `100m` | CPU limit |
 | `config.memoryRequest` | `64Mi` | Memory request |
@@ -132,6 +137,20 @@ config.pdnsToken: my-api-key
 config.pdnsZone: sthings.io
 ```
 
+### With DD-WRT DNS integration
+
+```yaml
+---
+config.image: ghcr.io/stuttgart-things/clusterbook:v1.11.0
+config.namespace: clusterbook
+config.configName: networks-labul
+config.ddwrtEnabled: true
+config.ddwrtHost: 192.168.1.1
+config.ddwrtUser: root
+config.ddwrtPassword: my-router-password
+config.ddwrtZone: sthings.lab
+```
+
 ## Rendered Resources
 
 | Resource | Name | Conditional |
@@ -145,4 +164,5 @@ config.pdnsZone: sthings.io
 | Service (gRPC) | `{name}` | Always |
 | Service (HTTP) | `{name}-http` | Always |
 | Secret | `{name}-pdns` | Only if `pdnsEnabled=true` |
+| Secret | `{name}-ddwrt` | Only if `ddwrtEnabled=true` |
 | HTTPRoute | `{name}` | Only if `httpRouteEnabled=true` |

--- a/kcl/configmap.k
+++ b/kcl/configmap.k
@@ -23,5 +23,9 @@ configMap = {
         PDNS_ENABLED: str(config.pdnsEnabled).lower()
         PDNS_URL: config.pdnsURL
         PDNS_ZONE: config.pdnsZone
+        DDWRT_ENABLED: str(config.ddwrtEnabled).lower()
+        DDWRT_HOST: config.ddwrtHost
+        DDWRT_USER: config.ddwrtUser
+        DDWRT_ZONE: config.ddwrtZone
     }
 }

--- a/kcl/deploy.k
+++ b/kcl/deploy.k
@@ -61,7 +61,13 @@ deployment = {
                                     name: "{}-pdns".format(config.name)
                                 }
                             }
-                        ] if config.pdnsEnabled else [])
+                        ] if config.pdnsEnabled else []) + ([
+                            {
+                                secretRef: {
+                                    name: "{}-ddwrt".format(config.name)
+                                }
+                            }
+                        ] if config.ddwrtEnabled else [])
                         resources: {
                             requests: {
                                 cpu: config.cpuRequest

--- a/kcl/labels.k
+++ b/kcl/labels.k
@@ -20,6 +20,11 @@ _pdnsEnabled = option("config.pdnsEnabled")
 _pdnsURL = option("config.pdnsURL")
 _pdnsToken = option("config.pdnsToken")
 _pdnsZone = option("config.pdnsZone")
+_ddwrtEnabled = option("config.ddwrtEnabled")
+_ddwrtHost = option("config.ddwrtHost")
+_ddwrtUser = option("config.ddwrtUser")
+_ddwrtPassword = option("config.ddwrtPassword")
+_ddwrtZone = option("config.ddwrtZone")
 
 # Config instance with command-line overrides
 config: schema.ClusterBook = schema.ClusterBook {
@@ -53,6 +58,16 @@ config: schema.ClusterBook = schema.ClusterBook {
         pdnsToken = _pdnsToken
     if _pdnsZone:
         pdnsZone = _pdnsZone
+    if _ddwrtEnabled:
+        ddwrtEnabled = _ddwrtEnabled in [True, "True", "true"]
+    if _ddwrtHost:
+        ddwrtHost = _ddwrtHost
+    if _ddwrtUser:
+        ddwrtUser = _ddwrtUser
+    if _ddwrtPassword:
+        ddwrtPassword = _ddwrtPassword
+    if _ddwrtZone:
+        ddwrtZone = _ddwrtZone
 }
 
 # Common labels applied to all resources

--- a/kcl/main.k
+++ b/kcl/main.k
@@ -21,6 +21,7 @@ manifests = [
         serviceaccount.serviceAccount
         configmap.configMap
         secret.pdnsSecret
+        secret.ddwrtSecret
         rbac.role
         rbac.roleBinding
         deploy.deployment

--- a/kcl/schema.k
+++ b/kcl/schema.k
@@ -48,6 +48,13 @@ schema ClusterBook:
     pdnsToken: str = ""
     pdnsZone: str = ""
 
+    # DD-WRT integration
+    ddwrtEnabled: bool = False
+    ddwrtHost: str = ""
+    ddwrtUser: str = ""
+    ddwrtPassword: str = ""
+    ddwrtZone: str = ""
+
     # RBAC
     networkConfigApiGroup: str = "github.stuttgart-things.com"
 

--- a/kcl/secret.k
+++ b/kcl/secret.k
@@ -19,3 +19,17 @@ pdnsSecret = {
         PDNS_TOKEN: config.pdnsToken
     }
 } if config.pdnsEnabled else None
+
+ddwrtSecret = {
+    apiVersion: "v1"
+    kind: "Secret"
+    metadata: {
+        name: "{}-ddwrt".format(config.name)
+        namespace: config.namespace
+        labels: labels.commonLabels
+    }
+    type: "Opaque"
+    stringData: {
+        DDWRT_PASSWORD: config.ddwrtPassword
+    }
+} if config.ddwrtEnabled else None


### PR DESCRIPTION
## Summary
- Add DD-WRT DNS provider fields to KCL schema (`ddwrtEnabled`, `ddwrtHost`, `ddwrtUser`, `ddwrtPassword`, `ddwrtZone`)
- Add DD-WRT config to ConfigMap (non-sensitive vars) and Secret (password only)
- Wire DD-WRT secret into Deployment `envFrom` (conditional, same pattern as PDNS)
- Add `option()` wiring in `labels.k` for `-D` CLI overrides
- Update README with DD-WRT feature, env vars, DNS providers section, credential handling
- Update KCL README with DD-WRT parameters, example profile, rendered resource

Closes #115

## Test plan
- [x] `kcl run main.k -D 'config.ddwrtEnabled=true' ...` renders ConfigMap, Secret, and Deployment correctly
- [x] DD-WRT Secret only rendered when `ddwrtEnabled=true`
- [x] Password stored in Secret, non-sensitive config in ConfigMap
- [x] `go test ./...` still passes

Generated with [Claude Code](https://claude.com/claude-code)