### PR TITLE
fix: strip network prefix from IP path value in PUT/DELETE handlers

### DIFF
--- a/internal/web.go
+++ b/internal/web.go
@@ -731,6 +731,10 @@ func handleAPIAddIP(w http.ResponseWriter, r *http.Request, loadFrom, configLoc,
 func handleAPIDeleteIP(w http.ResponseWriter, r *http.Request, loadFrom, configLoc, configNm string, pdns *PDNSClient, ddwrt *DDWRTClient) {
 	networkKey := r.PathValue("key")
 	ip := r.PathValue("ip")
+	// Support both full IP (10.31.104.5) and host-part only (5)
+	if strings.HasPrefix(ip, networkKey+".") {
+		ip = strings.TrimPrefix(ip, networkKey+".")
+	}
 
 	ipList := LoadProfile(loadFrom, configLoc, configNm)
 
@@ -770,6 +774,10 @@ func handleAPIDeleteIP(w http.ResponseWriter, r *http.Request, loadFrom, configL
 func handleAPIEditIP(w http.ResponseWriter, r *http.Request, loadFrom, configLoc, configNm string, pdns *PDNSClient, ddwrt *DDWRTClient) {
 	networkKey := r.PathValue("key")
 	ipDigit := r.PathValue("ip")
+	// Support both full IP (10.31.104.5) and host-part only (5)
+	if strings.HasPrefix(ipDigit, networkKey+".") {
+		ipDigit = strings.TrimPrefix(ipDigit, networkKey+".")
+	}
 
 	var req struct {
 		Cluster   string `json:"cluster"`


### PR DESCRIPTION
## Summary
- `handleAPIEditIP` and `handleAPIDeleteIP` return 404 when the `{ip}` path parameter contains the full IP (e.g. `10.31.104.5`) instead of just the host-part (`5`)
- Both handlers now strip the network key prefix before map lookup, accepting both formats
- Unblocks `provider-clusterbook` which sends full IPs in update/delete requests

Closes #139

## Test plan
- [x] `go test ./internal/... -v` passes
- [ ] Manual test: `PUT /api/v1/networks/10.31.104/ips/10.31.104.5` returns 200
- [ ] Manual test: `PUT /api/v1/networks/10.31.104/ips/5` still works (backwards compatible)

🤖 Generated with [Claude Code](https://claude.com/claude-code)