### PR TITLE
feat: add FQDN and zone fields to API responses

### DIFF
--- a/internal/web.go
+++ b/internal/web.go
@@ -26,10 +26,31 @@ type NetworkPoolInfo struct {
 
 // IPEntry holds a single IP entry for display
 type IPEntry struct {
-	IP      string
-	Digit   string
-	Status  string
-	Cluster string
+	IP      string `json:"ip"`
+	Digit   string `json:"digit"`
+	Status  string `json:"status"`
+	Cluster string `json:"cluster"`
+	FQDN    string `json:"fqdn,omitempty"`
+}
+
+// dnsZone returns the configured DNS zone (without trailing dot) from PDNS or DDWRT.
+// Returns empty string if neither is configured.
+func dnsZone(pdns *PDNSClient, ddwrt *DDWRTClient) string {
+	if pdns != nil {
+		return strings.TrimSuffix(pdns.Zone, ".")
+	}
+	if ddwrt != nil {
+		return ddwrt.Zone
+	}
+	return ""
+}
+
+// buildFQDN returns the wildcard FQDN for a cluster given a DNS zone.
+func buildFQDN(cluster, zone string) string {
+	if cluster == "" || zone == "" {
+		return ""
+	}
+	return fmt.Sprintf("*.%s.%s", cluster, zone)
 }
 
 // StartWebServer starts the HTTP server for HTMX frontend and REST API
@@ -49,7 +70,7 @@ func StartWebServer(httpPort, loadFrom, configLoc, configNm string, pdns *PDNSCl
 		handleAPINetworks(w, r, loadFrom, configLoc, configNm)
 	})
 	mux.HandleFunc("GET /api/v1/networks/{key}/ips", func(w http.ResponseWriter, r *http.Request) {
-		handleAPINetworkIPs(w, r, loadFrom, configLoc, configNm)
+		handleAPINetworkIPs(w, r, loadFrom, configLoc, configNm, pdns, ddwrt)
 	})
 	mux.HandleFunc("POST /api/v1/networks/{key}/assign", func(w http.ResponseWriter, r *http.Request) {
 		handleAPIAssign(w, r, loadFrom, configLoc, configNm, pdns, ddwrt)
@@ -88,7 +109,12 @@ func StartWebServer(httpPort, loadFrom, configLoc, configNm string, pdns *PDNSCl
 		handleAPIClusters(w, r, loadFrom, configLoc, configNm)
 	})
 	mux.HandleFunc("GET /api/v1/clusters/{name}", func(w http.ResponseWriter, r *http.Request) {
-		handleAPIClusterInfo(w, r, loadFrom, configLoc, configNm)
+		handleAPIClusterInfo(w, r, loadFrom, configLoc, configNm, pdns, ddwrt)
+	})
+
+	// Zone info endpoint
+	mux.HandleFunc("GET /api/v1/zone", func(w http.ResponseWriter, r *http.Request) {
+		handleAPIZone(w, r, pdns, ddwrt)
 	})
 
 	// HTMX partial routes
@@ -334,7 +360,7 @@ func handleAPINetworks(w http.ResponseWriter, r *http.Request, loadFrom, configL
 	json.NewEncoder(w).Encode(pools)
 }
 
-func handleAPINetworkIPs(w http.ResponseWriter, r *http.Request, loadFrom, configLoc, configNm string) {
+func handleAPINetworkIPs(w http.ResponseWriter, r *http.Request, loadFrom, configLoc, configNm string, pdns *PDNSClient, ddwrt *DDWRTClient) {
 	networkKey := r.PathValue("key")
 	ipList := LoadProfile(loadFrom, configLoc, configNm)
 
@@ -344,7 +370,14 @@ func handleAPINetworkIPs(w http.ResponseWriter, r *http.Request, loadFrom, confi
 		return
 	}
 
+	zone := dnsZone(pdns, ddwrt)
 	entries := getIPEntries(ips, networkKey)
+	for i := range entries {
+		if strings.Contains(entries[i].Status, ":DNS") && entries[i].Cluster != "" {
+			entries[i].FQDN = buildFQDN(entries[i].Cluster, zone)
+		}
+	}
+
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(entries)
 }
@@ -880,7 +913,7 @@ func handleAPIClusters(w http.ResponseWriter, r *http.Request, loadFrom, configL
 	json.NewEncoder(w).Encode(result)
 }
 
-func handleAPIClusterInfo(w http.ResponseWriter, r *http.Request, loadFrom, configLoc, configNm string) {
+func handleAPIClusterInfo(w http.ResponseWriter, r *http.Request, loadFrom, configLoc, configNm string, pdns *PDNSClient, ddwrt *DDWRTClient) {
 	clusterName := r.PathValue("name")
 	ipList := LoadProfile(loadFrom, configLoc, configNm)
 
@@ -891,6 +924,7 @@ func handleAPIClusterInfo(w http.ResponseWriter, r *http.Request, loadFrom, conf
 	}
 
 	var ips []ipInfo
+	hasDNS := false
 	for networkKey, network := range ipList {
 		for ipDigit, entry := range network {
 			if entry.Cluster == clusterName {
@@ -899,6 +933,9 @@ func handleAPIClusterInfo(w http.ResponseWriter, r *http.Request, loadFrom, conf
 					IP:      networkKey + "." + ipDigit,
 					Status:  entry.Status,
 				})
+				if strings.Contains(entry.Status, ":DNS") {
+					hasDNS = true
+				}
 			}
 		}
 	}
@@ -908,11 +945,50 @@ func handleAPIClusterInfo(w http.ResponseWriter, r *http.Request, loadFrom, conf
 		return
 	}
 
-	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(map[string]interface{}{
+	zone := dnsZone(pdns, ddwrt)
+	result := map[string]interface{}{
 		"cluster": clusterName,
 		"ips":     ips,
-	})
+	}
+	if hasDNS && zone != "" {
+		result["fqdn"] = buildFQDN(clusterName, zone)
+		result["zone"] = zone
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(result)
+}
+
+func handleAPIZone(w http.ResponseWriter, r *http.Request, pdns *PDNSClient, ddwrt *DDWRTClient) {
+	type providerInfo struct {
+		Enabled bool   `json:"enabled"`
+		Zone    string `json:"zone,omitempty"`
+	}
+
+	result := map[string]providerInfo{
+		"pdns": {
+			Enabled: pdns != nil,
+		},
+		"ddwrt": {
+			Enabled: ddwrt != nil,
+		},
+	}
+
+	if pdns != nil {
+		result["pdns"] = providerInfo{
+			Enabled: true,
+			Zone:    strings.TrimSuffix(pdns.Zone, "."),
+		}
+	}
+	if ddwrt != nil {
+		result["ddwrt"] = providerInfo{
+			Enabled: true,
+			Zone:    ddwrt.Zone,
+		}
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(result)
 }
 
 // --- HTMX CRUD Handlers ---

--- a/internal/web_test.go
+++ b/internal/web_test.go
@@ -80,7 +80,7 @@ func TestHandleAPIClusterInfo(t *testing.T) {
 		req.SetPathValue("name", "mycluster")
 		w := httptest.NewRecorder()
 
-		handleAPIClusterInfo(w, req, "disk", dir, name)
+		handleAPIClusterInfo(w, req, "disk", dir, name, nil, nil)
 
 		if w.Code != http.StatusOK {
 			t.Fatalf("expected 200, got %d", w.Code)
@@ -111,10 +111,189 @@ func TestHandleAPIClusterInfo(t *testing.T) {
 		req.SetPathValue("name", "doesnotexist")
 		w := httptest.NewRecorder()
 
-		handleAPIClusterInfo(w, req, "disk", dir, name)
+		handleAPIClusterInfo(w, req, "disk", dir, name, nil, nil)
 
 		if w.Code != http.StatusNotFound {
 			t.Errorf("expected 404, got %d", w.Code)
+		}
+	})
+
+	t.Run("includes fqdn and zone with PDNS provider", func(t *testing.T) {
+		pdns := &PDNSClient{Zone: "sthings-vsphere.labul.sva.de."}
+		req := httptest.NewRequest("GET", "/api/v1/clusters/mycluster", nil)
+		req.SetPathValue("name", "mycluster")
+		w := httptest.NewRecorder()
+
+		handleAPIClusterInfo(w, req, "disk", dir, name, pdns, nil)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d", w.Code)
+		}
+
+		var result struct {
+			Cluster string `json:"cluster"`
+			FQDN    string `json:"fqdn"`
+			Zone    string `json:"zone"`
+		}
+		if err := json.NewDecoder(w.Body).Decode(&result); err != nil {
+			t.Fatalf("decode error: %v", err)
+		}
+
+		expectedFQDN := "*.mycluster.sthings-vsphere.labul.sva.de"
+		if result.FQDN != expectedFQDN {
+			t.Errorf("expected fqdn %q, got %q", expectedFQDN, result.FQDN)
+		}
+		if result.Zone != "sthings-vsphere.labul.sva.de" {
+			t.Errorf("expected zone sthings-vsphere.labul.sva.de, got %q", result.Zone)
+		}
+	})
+
+	t.Run("no fqdn without DNS status", func(t *testing.T) {
+		pdns := &PDNSClient{Zone: "sthings.lab."}
+		req := httptest.NewRequest("GET", "/api/v1/clusters/othercluster", nil)
+		req.SetPathValue("name", "othercluster")
+		w := httptest.NewRecorder()
+
+		handleAPIClusterInfo(w, req, "disk", dir, name, pdns, nil)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d", w.Code)
+		}
+
+		var result map[string]interface{}
+		if err := json.NewDecoder(w.Body).Decode(&result); err != nil {
+			t.Fatalf("decode error: %v", err)
+		}
+
+		if _, ok := result["fqdn"]; ok {
+			t.Errorf("expected no fqdn field for cluster without DNS, got %v", result["fqdn"])
+		}
+	})
+}
+
+func TestHandleAPINetworkIPsWithFQDN(t *testing.T) {
+	dir, name := setupTestConfig(t, testConfigYAML)
+	pdns := &PDNSClient{Zone: "sthings-vsphere.labul.sva.de."}
+
+	req := httptest.NewRequest("GET", "/api/v1/networks/10.31.103/ips", nil)
+	req.SetPathValue("key", "10.31.103")
+	w := httptest.NewRecorder()
+
+	handleAPINetworkIPs(w, req, "disk", dir, name, pdns, nil)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+
+	var entries []IPEntry
+	if err := json.NewDecoder(w.Body).Decode(&entries); err != nil {
+		t.Fatalf("decode error: %v", err)
+	}
+
+	fqdnByDigit := map[string]string{}
+	for _, e := range entries {
+		fqdnByDigit[e.Digit] = e.FQDN
+	}
+
+	// digit "5" has ASSIGNED:DNS → should have FQDN
+	expected := "*.mycluster.sthings-vsphere.labul.sva.de"
+	if fqdnByDigit["5"] != expected {
+		t.Errorf("digit 5: expected fqdn %q, got %q", expected, fqdnByDigit["5"])
+	}
+
+	// digit "6" has ASSIGNED (no DNS) → no FQDN
+	if fqdnByDigit["6"] != "" {
+		t.Errorf("digit 6: expected empty fqdn, got %q", fqdnByDigit["6"])
+	}
+
+	// digit "7" is unassigned → no FQDN
+	if fqdnByDigit["7"] != "" {
+		t.Errorf("digit 7: expected empty fqdn, got %q", fqdnByDigit["7"])
+	}
+}
+
+func TestHandleAPIZone(t *testing.T) {
+	t.Run("with PDNS provider", func(t *testing.T) {
+		pdns := &PDNSClient{Zone: "sthings-vsphere.labul.sva.de."}
+		req := httptest.NewRequest("GET", "/api/v1/zone", nil)
+		w := httptest.NewRecorder()
+
+		handleAPIZone(w, req, pdns, nil)
+
+		var result map[string]struct {
+			Enabled bool   `json:"enabled"`
+			Zone    string `json:"zone"`
+		}
+		if err := json.NewDecoder(w.Body).Decode(&result); err != nil {
+			t.Fatalf("decode error: %v", err)
+		}
+
+		if !result["pdns"].Enabled {
+			t.Error("expected pdns enabled")
+		}
+		if result["pdns"].Zone != "sthings-vsphere.labul.sva.de" {
+			t.Errorf("expected zone sthings-vsphere.labul.sva.de, got %q", result["pdns"].Zone)
+		}
+		if result["ddwrt"].Enabled {
+			t.Error("expected ddwrt disabled")
+		}
+	})
+
+	t.Run("no providers", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/api/v1/zone", nil)
+		w := httptest.NewRecorder()
+
+		handleAPIZone(w, req, nil, nil)
+
+		var result map[string]struct {
+			Enabled bool   `json:"enabled"`
+			Zone    string `json:"zone"`
+		}
+		if err := json.NewDecoder(w.Body).Decode(&result); err != nil {
+			t.Fatalf("decode error: %v", err)
+		}
+
+		if result["pdns"].Enabled || result["ddwrt"].Enabled {
+			t.Error("expected both providers disabled")
+		}
+	})
+}
+
+func TestBuildFQDN(t *testing.T) {
+	tests := []struct {
+		cluster, zone, want string
+	}{
+		{"myapp", "sthings.lab", "*.myapp.sthings.lab"},
+		{"", "sthings.lab", ""},
+		{"myapp", "", ""},
+	}
+	for _, tt := range tests {
+		got := buildFQDN(tt.cluster, tt.zone)
+		if got != tt.want {
+			t.Errorf("buildFQDN(%q, %q) = %q, want %q", tt.cluster, tt.zone, got, tt.want)
+		}
+	}
+}
+
+func TestDnsZone(t *testing.T) {
+	t.Run("prefers PDNS zone", func(t *testing.T) {
+		pdns := &PDNSClient{Zone: "pdns.zone."}
+		ddwrt := &DDWRTClient{Zone: "ddwrt.zone"}
+		if got := dnsZone(pdns, ddwrt); got != "pdns.zone" {
+			t.Errorf("expected pdns.zone, got %q", got)
+		}
+	})
+
+	t.Run("falls back to DDWRT", func(t *testing.T) {
+		ddwrt := &DDWRTClient{Zone: "ddwrt.zone"}
+		if got := dnsZone(nil, ddwrt); got != "ddwrt.zone" {
+			t.Errorf("expected ddwrt.zone, got %q", got)
+		}
+	})
+
+	t.Run("returns empty when both nil", func(t *testing.T) {
+		if got := dnsZone(nil, nil); got != "" {
+			t.Errorf("expected empty, got %q", got)
 		}
 	})
 }


### PR DESCRIPTION
## Summary
- `GET /api/v1/clusters/{name}` now returns `fqdn` (e.g. `*.k3s-target-labul.sthings-vsphere.labul.sva.de`) and `zone` when the cluster has DNS-assigned IPs
- `GET /api/v1/networks/{key}/ips` includes `fqdn` per IP entry that has `:DNS` status
- New `GET /api/v1/zone` endpoint exposes configured PDNS and DDWRT provider zone info

## Test plan
- [x] Existing `TestHandleAPIClusters` and `TestHandleAPIClusterInfo` still pass
- [x] New `TestHandleAPIClusterInfo` subtests verify FQDN/zone present with PDNS provider, absent without DNS status
- [x] New `TestHandleAPINetworkIPsWithFQDN` verifies per-IP FQDN for DNS entries only
- [x] New `TestHandleAPIZone` covers enabled/disabled provider combos
- [x] New `TestBuildFQDN` and `TestDnsZone` unit tests for helper functions
- [x] Full test suite passes (`go test ./...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)