### PR TITLE
feat: add IP lease/expiry model with auto-reclaim

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -233,8 +233,6 @@ golang.org/x/crypto v0.0.0-20181203042331-505ab145d0a9/go.mod h1:6SG95UA2DQfeDnf
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
-golang.org/x/crypto v0.49.0 h1:+Ng2ULVvLHnJ/ZFEq4KdcDd/cfjrrjjNSXNzxg0Y4U4=
-golang.org/x/crypto v0.49.0/go.mod h1:ErX4dUh2UM+CFYiXZRTcMpEcN8b/1gxEuv3nODoYtCA=
 golang.org/x/crypto v0.50.0 h1:zO47/JPrL6vsNkINmLoo/PH1gcxpls50DNogFvB5ZGI=
 golang.org/x/crypto v0.50.0/go.mod h1:3muZ7vA7PBCE6xgPX7nkzzjiUq87kRItoJQM1Yo8S+Q=
 golang.org/x/exp v0.0.0-20220909182711-5c715a9e8561 h1:MDc5xs78ZrZr3HMQugiXOAkSZtfTpbJLDr/lwfgO53E=
@@ -255,8 +253,6 @@ golang.org/x/net v0.0.0-20190724013045-ca1201d0de80/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
 golang.org/x/net v0.6.0/go.mod h1:2Tu9+aMcznHK/AK1HMvgo6xiTLG5rD5rZLDS+rp2Bjs=
-golang.org/x/net v0.51.0 h1:94R/GTO7mt3/4wIKpcR5gkGmRLOuE/2hNGeWq/GBIFo=
-golang.org/x/net v0.51.0/go.mod h1:aamm+2QF5ogm02fjy5Bb7CQ0WMt1/WVM7FtyaTLlA9Y=
 golang.org/x/net v0.52.0 h1:He/TN1l0e4mmR3QqHMT2Xab3Aj3L9qjbhRm78/6jrW0=
 golang.org/x/net v0.52.0/go.mod h1:R1MAz7uMZxVMualyPXb+VaqGSa3LIaUqk0eEt3w36Sw=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
@@ -287,8 +283,6 @@ golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.5.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.42.0 h1:omrd2nAlyT5ESRdCLYdm3+fMfNFE/+Rf4bDIQImRJeo=
-golang.org/x/sys v0.42.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/sys v0.43.0 h1:Rlag2XtaFTxp19wS8MXlJwTvoh8ArU6ezoyFsMyCTNI=
 golang.org/x/sys v0.43.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
@@ -296,8 +290,6 @@ golang.org/x/term v0.0.0-20210220032956-6a3ed077a48d/go.mod h1:bj7SfCRtBDWHUb9sn
 golang.org/x/term v0.0.0-20210615171337-6886f2dfbf5b/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/term v0.5.0/go.mod h1:jMB1sMXY+tzblOD4FWmEbocvup2/aLOaQEp7JmGp78k=
-golang.org/x/term v0.41.0 h1:QCgPso/Q3RTJx2Th4bDLqML4W6iJiaXFq2/ftQF13YU=
-golang.org/x/term v0.41.0/go.mod h1:3pfBgksrReYfZ5lvYM0kSO0LIkAl4Yl2bXOkKP7Ec2A=
 golang.org/x/term v0.42.0 h1:UiKe+zDFmJobeJ5ggPwOshJIVt6/Ft0rcfrXZDLWAWY=
 golang.org/x/term v0.42.0/go.mod h1:Dq/D+snpsbazcBG5+F9Q1n2rXV8Ma+71xEjTRufARgY=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
@@ -306,8 +298,6 @@ golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
 golang.org/x/text v0.7.0/go.mod h1:mrYo+phRRbMaCq/xk9113O4dZlRixOauAjOtrjsXDZ8=
 golang.org/x/text v0.9.0/go.mod h1:e1OnstbJyHTd6l/uOt8jFFHp6TRDWZR/bV3emEE/zU8=
-golang.org/x/text v0.35.0 h1:JOVx6vVDFokkpaq1AEptVzLTpDe9KGpj5tR4/X+ybL8=
-golang.org/x/text v0.35.0/go.mod h1:khi/HExzZJ2pGnjenulevKNX1W67CUy0AsXcNubPGCA=
 golang.org/x/text v0.36.0 h1:JfKh3XmcRPqZPKevfXVpI1wXPTqbkE5f7JA92a55Yxg=
 golang.org/x/text v0.36.0/go.mod h1:NIdBknypM8iqVmPiuco0Dh6P5Jcdk8lJL0CUebqK164=
 golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=

--- a/internal/generate.go
+++ b/internal/generate.go
@@ -15,8 +15,9 @@ import (
 )
 
 type IPInfo struct {
-	Status  string `yaml:"status"`
-	Cluster string `yaml:"cluster"`
+	Status         string `yaml:"status"`
+	Cluster        string `yaml:"cluster"`
+	LeaseExpiresAt int64  `yaml:"lease_expires_at,omitempty"`
 }
 
 type IPs map[string]IPInfo

--- a/internal/reclaimer.go
+++ b/internal/reclaimer.go
@@ -1,0 +1,99 @@
+/*
+Copyright © 2024 Patrick Hermann patrick.hermann@sva.de
+*/
+
+package internal
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/pterm/pterm"
+)
+
+// ExpiredLease identifies an IP entry whose lease has expired.
+type ExpiredLease struct {
+	NetworkKey string
+	IPDigit    string
+	Cluster    string
+	HadDNS     bool
+}
+
+// FindExpiredLeases returns entries whose LeaseExpiresAt is non-zero and already in the past.
+func FindExpiredLeases(ipList map[string]IPs, now time.Time) []ExpiredLease {
+	var expired []ExpiredLease
+	for networkKey, ips := range ipList {
+		for digit, info := range ips {
+			if info.LeaseExpiresAt == 0 {
+				continue
+			}
+			if info.LeaseExpiresAt > now.Unix() {
+				continue
+			}
+			expired = append(expired, ExpiredLease{
+				NetworkKey: networkKey,
+				IPDigit:    digit,
+				Cluster:    info.Cluster,
+				HadDNS:     strings.HasSuffix(info.Status, ":DNS"),
+			})
+		}
+	}
+	return expired
+}
+
+// ReclaimExpiredLeases clears expired entries in-place, invokes DNS cleanup for entries
+// that had a DNS record, and returns the reclaimed leases.
+func ReclaimExpiredLeases(ipList map[string]IPs, now time.Time, pdns *PDNSClient, ddwrt *DDWRTClient) []ExpiredLease {
+	expired := FindExpiredLeases(ipList, now)
+	for _, e := range expired {
+		entry := ipList[e.NetworkKey][e.IPDigit]
+		entry.Status = ""
+		entry.Cluster = ""
+		entry.LeaseExpiresAt = 0
+		ipList[e.NetworkKey][e.IPDigit] = entry
+
+		if e.HadDNS && e.Cluster != "" {
+			if pdns != nil {
+				pdns.DeleteRecord(e.Cluster)
+			}
+			if ddwrt != nil {
+				if err := ddwrt.DeleteRecord(e.Cluster); err != nil {
+					pterm.DefaultLogger.WithLevel(pterm.LogLevelTrace).Warn("reclaimer ddwrt delete failed", pterm.DefaultLogger.Args("cluster", e.Cluster, "err", err))
+				}
+			}
+		}
+	}
+	return expired
+}
+
+// StartReclaimer runs a periodic loop that reclaims expired leases.
+// Disabled if interval is <= 0. Blocks until ctx is cancelled.
+func StartReclaimer(ctx context.Context, interval time.Duration, loadFrom, configLoc, configNm string, pdns *PDNSClient, ddwrt *DDWRTClient) {
+	logger := pterm.DefaultLogger.WithLevel(pterm.LogLevelTrace)
+	if interval <= 0 {
+		logger.Info("lease reclaimer disabled")
+		return
+	}
+	logger.Info("lease reclaimer started", logger.Args("interval", interval.String()))
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			logger.Info("lease reclaimer stopped")
+			return
+		case <-ticker.C:
+			ipList := LoadProfile(loadFrom, configLoc, configNm)
+			reclaimed := ReclaimExpiredLeases(ipList, time.Now(), pdns, ddwrt)
+			if len(reclaimed) > 0 {
+				saveConfig(ipList, loadFrom, configLoc, configNm)
+				for _, e := range reclaimed {
+					logger.Info("lease reclaimed", logger.Args("ip", e.NetworkKey+"."+e.IPDigit, "cluster", e.Cluster, "dns_cleanup", e.HadDNS))
+				}
+			}
+		}
+	}
+}

--- a/internal/reclaimer_test.go
+++ b/internal/reclaimer_test.go
@@ -1,0 +1,89 @@
+package internal
+
+import (
+	"testing"
+	"time"
+)
+
+func TestFindExpiredLeases(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0)
+
+	ipList := map[string]IPs{
+		"10.31.103": {
+			"4": {Status: "ASSIGNED", Cluster: "a", LeaseExpiresAt: 0},                    // no lease
+			"5": {Status: "ASSIGNED", Cluster: "b", LeaseExpiresAt: now.Unix() - 10},      // expired
+			"6": {Status: "ASSIGNED:DNS", Cluster: "c", LeaseExpiresAt: now.Unix() - 100}, // expired w/ DNS
+			"7": {Status: "ASSIGNED", Cluster: "d", LeaseExpiresAt: now.Unix() + 100},     // still valid
+		},
+	}
+
+	expired := FindExpiredLeases(ipList, now)
+
+	if len(expired) != 2 {
+		t.Fatalf("expected 2 expired, got %d", len(expired))
+	}
+
+	got := map[string]ExpiredLease{}
+	for _, e := range expired {
+		got[e.IPDigit] = e
+	}
+	if e, ok := got["5"]; !ok || e.HadDNS {
+		t.Errorf("digit 5: want expired without DNS, got %+v ok=%v", e, ok)
+	}
+	if e, ok := got["6"]; !ok || !e.HadDNS {
+		t.Errorf("digit 6: want expired with DNS, got %+v ok=%v", e, ok)
+	}
+}
+
+func TestReclaimExpiredLeasesClearsEntry(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0)
+
+	ipList := map[string]IPs{
+		"10.31.103": {
+			"5": {Status: "ASSIGNED", Cluster: "b", LeaseExpiresAt: now.Unix() - 10},
+			"7": {Status: "ASSIGNED", Cluster: "d", LeaseExpiresAt: now.Unix() + 100},
+		},
+	}
+
+	reclaimed := ReclaimExpiredLeases(ipList, now, nil, nil)
+	if len(reclaimed) != 1 {
+		t.Fatalf("expected 1 reclaimed, got %d", len(reclaimed))
+	}
+
+	cleared := ipList["10.31.103"]["5"]
+	if cleared.Status != "" || cleared.Cluster != "" || cleared.LeaseExpiresAt != 0 {
+		t.Errorf("digit 5: want fully cleared, got %+v", cleared)
+	}
+
+	untouched := ipList["10.31.103"]["7"]
+	if untouched.Status != "ASSIGNED" || untouched.Cluster != "d" {
+		t.Errorf("digit 7: want untouched, got %+v", untouched)
+	}
+}
+
+func TestReclaimExpiredLeasesCallsDDWRTDelete(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0)
+
+	ipList := map[string]IPs{
+		"10.31.103": {
+			"6": {Status: "ASSIGNED:DNS", Cluster: "c", LeaseExpiresAt: now.Unix() - 5},
+			"7": {Status: "ASSIGNED", Cluster: "d", LeaseExpiresAt: now.Unix() - 5}, // no DNS suffix
+		},
+	}
+
+	srv, err := NewFakeDDWRTServer("root", "testpass")
+	if err != nil {
+		t.Fatalf("fake ssh server: %v", err)
+	}
+	defer srv.Close()
+
+	srv.NvramSet("dnsmasq_options", "address=/c.sthings.lab/10.31.103.6")
+
+	ddwrt := NewDDWRTClient("true", srv.Addr, "root", "testpass", "sthings.lab")
+	ReclaimExpiredLeases(ipList, now, nil, ddwrt)
+
+	opts := srv.NvramGet("dnsmasq_options")
+	if opts != "" {
+		t.Errorf("expected DNS entry removed, still have: %q", opts)
+	}
+}

--- a/internal/transform.go
+++ b/internal/transform.go
@@ -6,8 +6,11 @@ package internal
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 )
+
+const crLeasePrefix = "exp="
 
 func TruncateIP(ip string) (string, error) {
 	segments := strings.Split(ip, ".")
@@ -39,13 +42,18 @@ func ConvertToCRFormat(info map[string]IPs) map[string][]string {
 	// Iterate over the info map to populate the networks map
 	for ip, ipDetails := range info {
 		for ipDigit, details := range ipDetails {
+			var entry string
 			if details.Status != "" && details.Cluster != "" {
 				// Format: "ipDigit:status:cluster"
-				networks[ip] = append(networks[ip], fmt.Sprintf("%s:%s:%s", ipDigit, details.Status, details.Cluster))
+				entry = fmt.Sprintf("%s:%s:%s", ipDigit, details.Status, details.Cluster)
 			} else {
 				// Just add the ipDigit if status or cluster is empty
-				networks[ip] = append(networks[ip], ipDigit)
+				entry = ipDigit
 			}
+			if details.LeaseExpiresAt != 0 {
+				entry = fmt.Sprintf("%s:%s%d", entry, crLeasePrefix, details.LeaseExpiresAt)
+			}
+			networks[ip] = append(networks[ip], entry)
 		}
 	}
 
@@ -60,9 +68,18 @@ func ConvertFromCRFormat(data map[string][]string) map[string]IPs {
 
 		for _, entry := range entries {
 			parts := strings.Split(entry, ":")
-			ipDigit := parts[0]
 
 			info := IPInfo{}
+			if len(parts) > 0 && strings.HasPrefix(parts[len(parts)-1], crLeasePrefix) {
+				raw := strings.TrimPrefix(parts[len(parts)-1], crLeasePrefix)
+				if v, err := strconv.ParseInt(raw, 10, 64); err == nil {
+					info.LeaseExpiresAt = v
+				}
+				parts = parts[:len(parts)-1]
+			}
+
+			ipDigit := parts[0]
+
 			if len(parts) > 1 {
 				info.Status = parts[1]
 				if len(parts) > 2 {

--- a/internal/transform_test.go
+++ b/internal/transform_test.go
@@ -117,6 +117,26 @@ func TestTruncateIP(t *testing.T) {
 	}
 }
 
+// TestConvertCRFormatRoundTripWithLease ensures the lease expiry survives round-trip
+// through the CR encoded-string format for every status-shape permutation.
+func TestConvertCRFormatRoundTripWithLease(t *testing.T) {
+	input := map[string]IPs{
+		"10.31.103": {
+			"3": {Status: "ASSIGNED", Cluster: "sandiego", LeaseExpiresAt: 1712345678},
+			"4": {Status: "ASSIGNED:DNS", Cluster: "miami", LeaseExpiresAt: 1799999999},
+			"5": {Status: "", Cluster: "", LeaseExpiresAt: 0},
+			"6": {Status: "ASSIGNED", Cluster: "no-lease"},
+		},
+	}
+
+	cr := ConvertToCRFormat(input)
+	out := ConvertFromCRFormat(cr)
+
+	if !reflect.DeepEqual(out, input) {
+		t.Errorf("round-trip mismatch:\nwant %+v\n got %+v", input, out)
+	}
+}
+
 // TestConvertFromCRFormat tests the ConvertFromCRFormat function
 func TestConvertFromCRFormat(t *testing.T) {
 	// Input data in CR format, including DNS suffix case

--- a/internal/web.go
+++ b/internal/web.go
@@ -13,6 +13,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 )
 
 // NetworkPoolInfo holds summary info for a network pool
@@ -26,11 +27,12 @@ type NetworkPoolInfo struct {
 
 // IPEntry holds a single IP entry for display
 type IPEntry struct {
-	IP      string `json:"ip"`
-	Digit   string `json:"digit"`
-	Status  string `json:"status"`
-	Cluster string `json:"cluster"`
-	FQDN    string `json:"fqdn,omitempty"`
+	IP             string `json:"ip"`
+	Digit          string `json:"digit"`
+	Status         string `json:"status"`
+	Cluster        string `json:"cluster"`
+	FQDN           string `json:"fqdn,omitempty"`
+	LeaseExpiresAt int64  `json:"lease_expires_at,omitempty"`
 }
 
 // dnsZone returns the configured DNS zone (without trailing dot) from PDNS or DDWRT.
@@ -80,6 +82,9 @@ func StartWebServer(httpPort, loadFrom, configLoc, configNm string, pdns *PDNSCl
 	})
 	mux.HandleFunc("POST /api/v1/networks/{key}/release", func(w http.ResponseWriter, r *http.Request) {
 		handleAPIRelease(w, r, loadFrom, configLoc, configNm, pdns, ddwrt)
+	})
+	mux.HandleFunc("POST /api/v1/networks/{key}/ips/{ip}/renew", func(w http.ResponseWriter, r *http.Request) {
+		handleAPIRenewLease(w, r, loadFrom, configLoc, configNm)
 	})
 
 	// REST API CRUD routes
@@ -177,10 +182,11 @@ func getIPEntries(ips IPs, networkKey string) []IPEntry {
 	var entries []IPEntry
 	for digit, info := range ips {
 		entries = append(entries, IPEntry{
-			IP:      networkKey + "." + digit,
-			Digit:   digit,
-			Status:  info.Status,
-			Cluster: info.Cluster,
+			IP:             networkKey + "." + digit,
+			Digit:          digit,
+			Status:         info.Status,
+			Cluster:        info.Cluster,
+			LeaseExpiresAt: info.LeaseExpiresAt,
 		})
 	}
 	sort.Slice(entries, func(i, j int) bool {
@@ -199,7 +205,6 @@ type dashboardData struct {
 	Commit    string
 	StartTime string
 }
-
 
 func handleDashboard(w http.ResponseWriter, r *http.Request, loadFrom, configLoc, configNm string) {
 	ipList := LoadProfile(loadFrom, configLoc, configNm)
@@ -386,10 +391,11 @@ func handleAPIAssign(w http.ResponseWriter, r *http.Request, loadFrom, configLoc
 	networkKey := r.PathValue("key")
 
 	var req struct {
-		IP        string `json:"ip"`
-		Cluster   string `json:"cluster"`
-		Status    string `json:"status"`
-		CreateDNS bool   `json:"create_dns"`
+		IP                   string `json:"ip"`
+		Cluster              string `json:"cluster"`
+		Status               string `json:"status"`
+		CreateDNS            bool   `json:"create_dns"`
+		LeaseDurationSeconds int64  `json:"lease_duration_seconds"`
 	}
 
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
@@ -425,6 +431,11 @@ func handleAPIAssign(w http.ResponseWriter, r *http.Request, loadFrom, configLoc
 		entry.Status = req.Status + ":DNS"
 	}
 	entry.Cluster = req.Cluster
+	if req.LeaseDurationSeconds > 0 {
+		entry.LeaseExpiresAt = time.Now().Unix() + req.LeaseDurationSeconds
+	} else {
+		entry.LeaseExpiresAt = 0
+	}
 	ipList[networkKey][ipDigit] = entry
 
 	saveConfig(ipList, loadFrom, configLoc, configNm)
@@ -448,9 +459,10 @@ func handleAPIReserve(w http.ResponseWriter, r *http.Request, loadFrom, configLo
 	networkKey := r.PathValue("key")
 
 	var req struct {
-		Cluster   string `json:"cluster"`
-		Status    string `json:"status"`
-		CreateDNS bool   `json:"create_dns"`
+		Cluster              string `json:"cluster"`
+		Status               string `json:"status"`
+		CreateDNS            bool   `json:"create_dns"`
+		LeaseDurationSeconds int64  `json:"lease_duration_seconds"`
 	}
 
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
@@ -498,6 +510,11 @@ func handleAPIReserve(w http.ResponseWriter, r *http.Request, loadFrom, configLo
 		entry.Status = req.Status + ":DNS"
 	}
 	entry.Cluster = req.Cluster
+	if req.LeaseDurationSeconds > 0 {
+		entry.LeaseExpiresAt = time.Now().Unix() + req.LeaseDurationSeconds
+	} else {
+		entry.LeaseExpiresAt = 0
+	}
 	ipList[networkKey][foundDigit] = entry
 
 	saveConfig(ipList, loadFrom, configLoc, configNm)
@@ -548,6 +565,7 @@ func handleAPIRelease(w http.ResponseWriter, r *http.Request, loadFrom, configLo
 	hadDNS := strings.HasSuffix(entry.Status, ":DNS")
 	entry.Status = ""
 	entry.Cluster = ""
+	entry.LeaseExpiresAt = 0
 	ipList[networkKey][ipDigit] = entry
 
 	saveConfig(ipList, loadFrom, configLoc, configNm)
@@ -563,6 +581,60 @@ func handleAPIRelease(w http.ResponseWriter, r *http.Request, loadFrom, configLo
 	json.NewEncoder(w).Encode(map[string]string{
 		"status":  "ok",
 		"message": fmt.Sprintf("IP %s released", req.IP),
+	})
+}
+
+func handleAPIRenewLease(w http.ResponseWriter, r *http.Request, loadFrom, configLoc, configNm string) {
+	networkKey := r.PathValue("key")
+	ip := r.PathValue("ip")
+
+	var req struct {
+		LeaseDurationSeconds int64 `json:"lease_duration_seconds"`
+	}
+
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, `{"error":"invalid request body"}`, http.StatusBadRequest)
+		return
+	}
+
+	if req.LeaseDurationSeconds <= 0 {
+		http.Error(w, `{"error":"lease_duration_seconds must be > 0"}`, http.StatusBadRequest)
+		return
+	}
+
+	ipList := LoadProfile(loadFrom, configLoc, configNm)
+
+	if _, ok := ipList[networkKey]; !ok {
+		http.Error(w, `{"error":"network not found"}`, http.StatusNotFound)
+		return
+	}
+
+	ipDigit, err := GetLastIPDigit(ip)
+	if err != nil {
+		http.Error(w, fmt.Sprintf(`{"error":"%s"}`, err.Error()), http.StatusBadRequest)
+		return
+	}
+
+	entry, ok := ipList[networkKey][ipDigit]
+	if !ok {
+		http.Error(w, `{"error":"ip not found"}`, http.StatusNotFound)
+		return
+	}
+	if entry.Status == "" {
+		http.Error(w, `{"error":"ip is not assigned"}`, http.StatusConflict)
+		return
+	}
+
+	entry.LeaseExpiresAt = time.Now().Unix() + req.LeaseDurationSeconds
+	ipList[networkKey][ipDigit] = entry
+
+	saveConfig(ipList, loadFrom, configLoc, configNm)
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]any{
+		"status":           "ok",
+		"ip":               ip,
+		"lease_expires_at": entry.LeaseExpiresAt,
 	})
 }
 

--- a/internal/web_test.go
+++ b/internal/web_test.go
@@ -6,7 +6,9 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
+	"time"
 )
 
 func setupTestConfig(t *testing.T, yaml string) (configDir, configName string) {
@@ -257,6 +259,100 @@ func TestHandleAPIZone(t *testing.T) {
 			t.Error("expected both providers disabled")
 		}
 	})
+}
+
+func TestHandleAPIAssignWithLease(t *testing.T) {
+	dir, name := setupTestConfig(t, testConfigYAML)
+
+	body := `{"ip":"10.31.103.7","cluster":"newcluster","lease_duration_seconds":3600}`
+	req := httptest.NewRequest("POST", "/api/v1/networks/10.31.103/assign", strings.NewReader(body))
+	req.SetPathValue("key", "10.31.103")
+	w := httptest.NewRecorder()
+
+	before := time.Now().Unix()
+	handleAPIAssign(w, req, "disk", dir, name, nil, nil)
+	after := time.Now().Unix()
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	ipList := LoadProfile("disk", dir, name)
+	entry := ipList["10.31.103"]["7"]
+	if entry.Status != "ASSIGNED" || entry.Cluster != "newcluster" {
+		t.Errorf("entry not assigned: %+v", entry)
+	}
+	if entry.LeaseExpiresAt < before+3600 || entry.LeaseExpiresAt > after+3600 {
+		t.Errorf("unexpected LeaseExpiresAt: got %d, want within [%d, %d]",
+			entry.LeaseExpiresAt, before+3600, after+3600)
+	}
+}
+
+func TestHandleAPIRenewLease(t *testing.T) {
+	dir, name := setupTestConfig(t, testConfigYAML)
+
+	body := `{"lease_duration_seconds":7200}`
+	req := httptest.NewRequest("POST", "/api/v1/networks/10.31.103/ips/10.31.103.6/renew", strings.NewReader(body))
+	req.SetPathValue("key", "10.31.103")
+	req.SetPathValue("ip", "10.31.103.6")
+	w := httptest.NewRecorder()
+
+	before := time.Now().Unix()
+	handleAPIRenewLease(w, req, "disk", dir, name)
+	after := time.Now().Unix()
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	ipList := LoadProfile("disk", dir, name)
+	entry := ipList["10.31.103"]["6"]
+	if entry.LeaseExpiresAt < before+7200 || entry.LeaseExpiresAt > after+7200 {
+		t.Errorf("unexpected LeaseExpiresAt after renew: %d", entry.LeaseExpiresAt)
+	}
+}
+
+func TestHandleAPIRenewLeaseRejectsUnassigned(t *testing.T) {
+	dir, name := setupTestConfig(t, testConfigYAML)
+
+	body := `{"lease_duration_seconds":3600}`
+	req := httptest.NewRequest("POST", "/api/v1/networks/10.31.103/ips/10.31.103.7/renew", strings.NewReader(body))
+	req.SetPathValue("key", "10.31.103")
+	req.SetPathValue("ip", "10.31.103.7")
+	w := httptest.NewRecorder()
+
+	handleAPIRenewLease(w, req, "disk", dir, name)
+
+	if w.Code != http.StatusConflict {
+		t.Errorf("expected 409 for unassigned IP, got %d", w.Code)
+	}
+}
+
+func TestHandleAPIReleaseClearsLease(t *testing.T) {
+	dir, name := setupTestConfig(t, testConfigYAML)
+
+	// First assign with lease
+	assignBody := `{"ip":"10.31.103.7","cluster":"temp","lease_duration_seconds":3600}`
+	assignReq := httptest.NewRequest("POST", "/api/v1/networks/10.31.103/assign", strings.NewReader(assignBody))
+	assignReq.SetPathValue("key", "10.31.103")
+	handleAPIAssign(httptest.NewRecorder(), assignReq, "disk", dir, name, nil, nil)
+
+	// Then release
+	releaseBody := `{"ip":"10.31.103.7"}`
+	releaseReq := httptest.NewRequest("POST", "/api/v1/networks/10.31.103/release", strings.NewReader(releaseBody))
+	releaseReq.SetPathValue("key", "10.31.103")
+	w := httptest.NewRecorder()
+	handleAPIRelease(w, releaseReq, "disk", dir, name, nil, nil)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+
+	ipList := LoadProfile("disk", dir, name)
+	entry := ipList["10.31.103"]["7"]
+	if entry.LeaseExpiresAt != 0 {
+		t.Errorf("expected lease cleared after release, got %d", entry.LeaseExpiresAt)
+	}
 }
 
 func TestBuildFQDN(t *testing.T) {

--- a/main.go
+++ b/main.go
@@ -11,6 +11,7 @@ import (
 	"net"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/pterm/pterm"
 	"github.com/stuttgart-things/clusterbook/internal"
@@ -44,7 +45,12 @@ var (
 	ddwrtUser      = os.Getenv("DDWRT_USER")
 	ddwrtPassword  = os.Getenv("DDWRT_PASSWORD")
 	ddwrtZone      = os.Getenv("DDWRT_ZONE")
+	reclaimerInt   = os.Getenv("RECLAIMER_INTERVAL")
 )
+
+// defaultReclaimerInterval is used when RECLAIMER_INTERVAL is empty.
+// Set RECLAIMER_INTERVAL=0 (or a negative duration) to disable.
+const defaultReclaimerInterval = 60 * time.Second
 
 func (s *server) GetIpAddressRange(ctx context.Context, req *ipservice.IpRequest) (*ipservice.IpResponse, error) {
 	logger.Info("LOAD CONFIG FROM", logger.Args("", loadConfigFrom))
@@ -154,6 +160,17 @@ func main() {
 
 	// START HTTP/HTMX SERVER IN BACKGROUND
 	go internal.StartWebServer(httpPort, loadConfigFrom, configLocation, configName, pdns, ddwrt)
+
+	// START LEASE RECLAIMER IN BACKGROUND
+	interval := defaultReclaimerInterval
+	if reclaimerInt != "" {
+		if d, err := time.ParseDuration(reclaimerInt); err == nil {
+			interval = d
+		} else {
+			logger.Warn("INVALID RECLAIMER_INTERVAL, USING DEFAULT", logger.Args("value", reclaimerInt, "default", interval.String()))
+		}
+	}
+	go internal.StartReclaimer(context.Background(), interval, loadConfigFrom, configLocation, configName, pdns, ddwrt)
 
 	lis, err := net.Listen("tcp", serverPort)
 	if err != nil {


### PR DESCRIPTION
## Summary
Closes #75.

- Add `LeaseExpiresAt` (unix seconds) to `IPInfo`; zero value = no lease
- `POST /api/v1/networks/{key}/assign` and `/reserve` accept optional `lease_duration_seconds`
- New `POST /api/v1/networks/{key}/ips/{ip}/renew` endpoint (body: `{"lease_duration_seconds": N}`)
- Release clears both the status and the lease
- Background reclaimer goroutine scans for expired leases, frees the IP, and triggers DNS cleanup for `*:DNS` entries
- `RECLAIMER_INTERVAL` env var controls cadence (default `60s`; `0` or negative duration disables)
- CR format round-trips the expiry via a trailing `exp=<unix>` segment — backwards compatible with existing entries

## Test plan
- [x] `go test ./...` passes
- [x] Reclaimer unit tests (pure + DD-WRT fake SSH integration)
- [x] Transform CR round-trip test covers all status/DNS/lease combinations
- [x] Web handler tests for assign-with-lease, renew, renew-rejects-unassigned, release-clears-lease

## Follow-ups (not in this PR)
- Expose `RECLAIMER_INTERVAL` in `kcl/configmap.k` / schema
- Extend gRPC `ClusterRequest` / add `RenewLease` RPC
- Heartbeat-based liveness check from assigned clusters

🤖 Generated with [Claude Code](https://claude.com/claude-code)