### PR TITLE
fix: accept createDNS on reserve/assign and prevent double :DNS suffix

### DIFF
--- a/internal/web.go
+++ b/internal/web.go
@@ -395,12 +395,17 @@ func handleAPIAssign(w http.ResponseWriter, r *http.Request, loadFrom, configLoc
 		Cluster              string `json:"cluster"`
 		Status               string `json:"status"`
 		CreateDNS            bool   `json:"create_dns"`
+		CreateDNSAlt         bool   `json:"createDNS"`
 		LeaseDurationSeconds int64  `json:"lease_duration_seconds"`
 	}
 
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		http.Error(w, `{"error":"invalid request body"}`, http.StatusBadRequest)
 		return
+	}
+
+	if req.CreateDNSAlt {
+		req.CreateDNS = true
 	}
 
 	if req.IP == "" || req.Cluster == "" {
@@ -462,12 +467,17 @@ func handleAPIReserve(w http.ResponseWriter, r *http.Request, loadFrom, configLo
 		Cluster              string `json:"cluster"`
 		Status               string `json:"status"`
 		CreateDNS            bool   `json:"create_dns"`
+		CreateDNSAlt         bool   `json:"createDNS"`
 		LeaseDurationSeconds int64  `json:"lease_duration_seconds"`
 	}
 
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		http.Error(w, `{"error":"invalid request body"}`, http.StatusBadRequest)
 		return
+	}
+
+	if req.CreateDNSAlt {
+		req.CreateDNS = true
 	}
 
 	if req.Cluster == "" {
@@ -527,10 +537,11 @@ func handleAPIReserve(w http.ResponseWriter, r *http.Request, loadFrom, configLo
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(map[string]string{
+	json.NewEncoder(w).Encode(map[string]any{
 		"ip":      fullIP,
+		"ips":     []string{fullIP},
 		"digit":   foundDigit,
-		"status":  req.Status,
+		"status":  entry.Status,
 		"cluster": req.Cluster,
 	})
 }
@@ -923,9 +934,10 @@ func handleAPIEditIP(w http.ResponseWriter, r *http.Request, loadFrom, configLoc
 	prevCluster := entry.Cluster
 	hadDNS := strings.HasSuffix(entry.Status, ":DNS")
 
-	entry.Status = req.Status
+	baseStatus := strings.TrimSuffix(req.Status, ":DNS")
+	entry.Status = baseStatus
 	if req.CreateDNS {
-		entry.Status = req.Status + ":DNS"
+		entry.Status = baseStatus + ":DNS"
 	}
 	entry.Cluster = req.Cluster
 	ipList[networkKey][ipDigit] = entry

--- a/internal/web_test.go
+++ b/internal/web_test.go
@@ -288,6 +288,150 @@ func TestHandleAPIAssignWithLease(t *testing.T) {
 	}
 }
 
+// Regression tests for #150 — reserve with createDNS=true:
+// - camelCase createDNS is accepted (operator dialect, not just create_dns)
+// - response contains an "ips" array so clients expecting that shape can parse it
+// - follow-up edit doesn't double-append ":DNS" to the status
+// - list-ips carries an fqdn field on the new entry end-to-end
+func TestHandleAPIReserveAcceptsCamelCaseCreateDNS(t *testing.T) {
+	dir, name := setupTestConfig(t, testConfigYAML)
+
+	body := `{"cluster":"smoke-alloc","count":1,"createDNS":true}`
+	req := httptest.NewRequest("POST", "/api/v1/networks/10.31.103/reserve", strings.NewReader(body))
+	req.SetPathValue("key", "10.31.103")
+	w := httptest.NewRecorder()
+
+	handleAPIReserve(w, req, "disk", dir, name, nil, nil)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp struct {
+		IP      string   `json:"ip"`
+		IPs     []string `json:"ips"`
+		Status  string   `json:"status"`
+		Cluster string   `json:"cluster"`
+	}
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode error: %v", err)
+	}
+
+	if resp.Cluster != "smoke-alloc" {
+		t.Errorf("cluster in response: got %q, want %q", resp.Cluster, "smoke-alloc")
+	}
+	if resp.Status != "ASSIGNED:DNS" {
+		t.Errorf("status in response: got %q, want %q", resp.Status, "ASSIGNED:DNS")
+	}
+	if resp.IP == "" {
+		t.Errorf("ip field missing")
+	}
+	if len(resp.IPs) != 1 || resp.IPs[0] != resp.IP {
+		t.Errorf("ips field: got %v, want [%q]", resp.IPs, resp.IP)
+	}
+
+	// Persisted entry should match — cluster kept intact, :DNS suffix set.
+	ipList := LoadProfile("disk", dir, name)
+	digit := strings.TrimPrefix(resp.IP, "10.31.103.")
+	entry := ipList["10.31.103"][digit]
+	if entry.Cluster != "smoke-alloc" {
+		t.Errorf("persisted cluster: got %q, want %q", entry.Cluster, "smoke-alloc")
+	}
+	if entry.Status != "ASSIGNED:DNS" {
+		t.Errorf("persisted status: got %q, want %q", entry.Status, "ASSIGNED:DNS")
+	}
+}
+
+func TestHandleAPIAssignAcceptsCamelCaseCreateDNS(t *testing.T) {
+	dir, name := setupTestConfig(t, testConfigYAML)
+
+	body := `{"ip":"10.31.103.7","cluster":"smoke-assign","status":"ASSIGNED","createDNS":true}`
+	req := httptest.NewRequest("POST", "/api/v1/networks/10.31.103/assign", strings.NewReader(body))
+	req.SetPathValue("key", "10.31.103")
+	w := httptest.NewRecorder()
+
+	handleAPIAssign(w, req, "disk", dir, name, nil, nil)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	entry := LoadProfile("disk", dir, name)["10.31.103"]["7"]
+	if entry.Cluster != "smoke-assign" {
+		t.Errorf("cluster: got %q, want %q", entry.Cluster, "smoke-assign")
+	}
+	if entry.Status != "ASSIGNED:DNS" {
+		t.Errorf("status: got %q, want %q", entry.Status, "ASSIGNED:DNS")
+	}
+}
+
+func TestHandleAPIEditIPDoesNotDoubleSuffixDNS(t *testing.T) {
+	dir, name := setupTestConfig(t, testConfigYAML)
+
+	// Mirrors the operator's drift-reconcile body: pre-suffixed status + createDNS=true.
+	body := `{"cluster":"mycluster","status":"ASSIGNED:DNS","createDNS":true}`
+	req := httptest.NewRequest("PUT", "/api/v1/networks/10.31.103/ips/6", strings.NewReader(body))
+	req.SetPathValue("key", "10.31.103")
+	req.SetPathValue("ip", "6")
+	w := httptest.NewRecorder()
+
+	handleAPIEditIP(w, req, "disk", dir, name, nil, nil)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	entry := LoadProfile("disk", dir, name)["10.31.103"]["6"]
+	if entry.Status != "ASSIGNED:DNS" {
+		t.Errorf("status: got %q, want %q (no double :DNS)", entry.Status, "ASSIGNED:DNS")
+	}
+}
+
+func TestHandleAPIReserveThenListIPsIncludesFQDN(t *testing.T) {
+	dir, name := setupTestConfig(t, testConfigYAML)
+	// DDWRT with a fake executor gives us a zone without touching SSH or HTTP.
+	ddwrt := newDDWRTClientWithExecutor("sthings.lab", newFakeExecutor())
+
+	reserveBody := `{"cluster":"e2e-alloc","createDNS":true}`
+	reserveReq := httptest.NewRequest("POST", "/api/v1/networks/10.31.104/reserve", strings.NewReader(reserveBody))
+	reserveReq.SetPathValue("key", "10.31.104")
+	reserveW := httptest.NewRecorder()
+	handleAPIReserve(reserveW, reserveReq, "disk", dir, name, nil, ddwrt)
+	if reserveW.Code != http.StatusOK {
+		t.Fatalf("reserve: expected 200, got %d: %s", reserveW.Code, reserveW.Body.String())
+	}
+
+	listReq := httptest.NewRequest("GET", "/api/v1/networks/10.31.104/ips", nil)
+	listReq.SetPathValue("key", "10.31.104")
+	listW := httptest.NewRecorder()
+	handleAPINetworkIPs(listW, listReq, "disk", dir, name, nil, ddwrt)
+	if listW.Code != http.StatusOK {
+		t.Fatalf("list: expected 200, got %d: %s", listW.Code, listW.Body.String())
+	}
+
+	var entries []IPEntry
+	if err := json.NewDecoder(listW.Body).Decode(&entries); err != nil {
+		t.Fatalf("decode error: %v", err)
+	}
+
+	var found *IPEntry
+	for i, e := range entries {
+		if e.Cluster == "e2e-alloc" {
+			found = &entries[i]
+			break
+		}
+	}
+	if found == nil {
+		t.Fatalf("reserved entry not in listing; entries=%+v", entries)
+	}
+	if found.Status != "ASSIGNED:DNS" {
+		t.Errorf("listing status: got %q, want ASSIGNED:DNS", found.Status)
+	}
+	if found.FQDN != "*.e2e-alloc.sthings.lab" {
+		t.Errorf("listing fqdn: got %q, want *.e2e-alloc.sthings.lab", found.FQDN)
+	}
+}
+
 func TestHandleAPIRenewLease(t *testing.T) {
 	dir, name := setupTestConfig(t, testConfigYAML)
 


### PR DESCRIPTION
## Summary
- `handleAPIReserve` and `handleAPIAssign` now accept both `create_dns` and `createDNS` (mirrors the #141 shim on `handleAPIEditIP`) so the operator's camelCase dialect no longer silently drops through as `false`.
- `handleAPIReserve` response now includes an `ips` array alongside `ip` so clients expecting that shape don't hit `len(ips)==0` and retry.
- `handleAPIEditIP` strips a trailing `:DNS` from the input status before conditionally re-appending, preventing `ASSIGNED:DNS:DNS` on the drift-reconcile path.

Closes #150

## Root cause
I verified with a small Go program that `encoding/json` does **not** map an incoming `createDNS` key onto a field tagged `json:"create_dns"` — the decoder just drops it, silently leaving `req.CreateDNS=false`. So a reserve with `createDNS: true`:
- skipped the `:DNS` status suffix,
- skipped the PDNS/DD-WRT `CreateRecord` call,
- and the operator (expecting `ips` array in the response) saw `len(ips)==0` and retried through the edit endpoint, which then double-suffixed to `ASSIGNED:DNS:DNS`.

## Test plan
- [x] `TestHandleAPIReserveAcceptsCamelCaseCreateDNS` — camelCase key, response has `ips` array, persisted `cluster` unchanged, status `ASSIGNED:DNS`
- [x] `TestHandleAPIAssignAcceptsCamelCaseCreateDNS` — same shim applied to `/assign`
- [x] `TestHandleAPIEditIPDoesNotDoubleSuffixDNS` — pre-suffixed input stays `ASSIGNED:DNS`
- [x] `TestHandleAPIReserveThenListIPsIncludesFQDN` — end-to-end: reserve with DDWRT provider → `/ips` listing carries the `fqdn` field on the new entry
- [x] Full internal test suite passes (`go test ./internal/...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)