### PR TITLE
fix: keep clusterbook running when NetworkConfig CR is missing

### DIFF
--- a/internal/load.go
+++ b/internal/load.go
@@ -6,7 +6,7 @@ package internal
 
 import (
 	"context"
-	"log"
+	"fmt"
 	"os"
 
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -36,33 +36,32 @@ func ReadYAMLFileFromDisk(filePath string) ([]byte, error) {
 	return os.ReadFile(filePath)
 }
 
-func LoadProfile(source, configLocation, configName string) (ipList map[string]IPs) {
-	// READ YAML FILE
-	var err error
-	var yamlData []byte
-
+// LoadProfile reads the NetworkConfig from the configured source (disk or CR).
+// It returns an error instead of terminating the process so that callers — web
+// handlers, gRPC handlers, and the background reclaimer — can fail a single
+// operation gracefully rather than crashing the whole server (and its readiness
+// probe) when the config is temporarily missing or unreachable.
+func LoadProfile(source, configLocation, configName string) (map[string]IPs, error) {
 	switch source {
 	// READ NetworkConfig FROM DISK
 	case "disk":
-		yamlData, err = ReadYAMLFileFromDisk(configLocation + "/" + configName)
+		yamlData, err := ReadYAMLFileFromDisk(configLocation + "/" + configName)
 		if err != nil {
-			log.Fatalf("error: %v", err)
+			return nil, fmt.Errorf("load profile: read yaml from disk %q: %w", configLocation+"/"+configName, err)
 		}
-		ipList = LoadYAMLStructure(yamlData)
+		return LoadYAMLStructure(yamlData), nil
 
 	// READ NetworkConfig FROM CR
 	case "cr":
 		retrievedConfig, err := GetNetworkConfig(configName, configLocation)
 		if err != nil {
-			log.Fatalf("Failed to get NetworkConfig: %v", err)
+			return nil, fmt.Errorf("load profile: get networkconfig %q in namespace %q: %w", configName, configLocation, err)
 		}
-		ipList = ConvertFromCRFormat(retrievedConfig.Spec.Networks)
+		return ConvertFromCRFormat(retrievedConfig.Spec.Networks), nil
 
 	default:
-		log.Fatalf("INVALID LOAD_CONFIG_FROM VALUE: %s", source)
+		return nil, fmt.Errorf("load profile: invalid LOAD_CONFIG_FROM value: %q", source)
 	}
-
-	return
 }
 
 // FUNCTION TO GET A NETWORKCONFIG RESOURCE

--- a/internal/load.go
+++ b/internal/load.go
@@ -9,6 +9,8 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/pterm/pterm"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -55,6 +57,16 @@ func LoadProfile(source, configLocation, configName string) (map[string]IPs, err
 	case "cr":
 		retrievedConfig, err := GetNetworkConfig(configName, configLocation)
 		if err != nil {
+			// A missing CR is not an error: the app self-bootstraps. Start with
+			// an empty config so the server stays usable; the first network/IP
+			// write creates the CR via CreateOrUpdateNetworkConfig.
+			if apierrors.IsNotFound(err) {
+				pterm.DefaultLogger.WithLevel(pterm.LogLevelTrace).Info(
+					"NetworkConfig not found, starting with empty config (will be created on first write)",
+					pterm.DefaultLogger.Args("name", configName, "namespace", configLocation),
+				)
+				return map[string]IPs{}, nil
+			}
 			return nil, fmt.Errorf("load profile: get networkconfig %q in namespace %q: %w", configName, configLocation, err)
 		}
 		return ConvertFromCRFormat(retrievedConfig.Spec.Networks), nil

--- a/internal/load_test.go
+++ b/internal/load_test.go
@@ -77,6 +77,9 @@ func TestReadYAMLFileFromDisk(t *testing.T) {
 }
 
 func TestLoadProfile(t *testing.T) {
-	ipList := LoadProfile("disk", "../tests", "config.yaml")
+	ipList, err := LoadProfile("disk", "../tests", "config.yaml")
+	if err != nil {
+		t.Fatalf("LoadProfile: %v", err)
+	}
 	fmt.Println(ipList)
 }

--- a/internal/reclaimer.go
+++ b/internal/reclaimer.go
@@ -86,7 +86,11 @@ func StartReclaimer(ctx context.Context, interval time.Duration, loadFrom, confi
 			logger.Info("lease reclaimer stopped")
 			return
 		case <-ticker.C:
-			ipList := LoadProfile(loadFrom, configLoc, configNm)
+			ipList, err := LoadProfile(loadFrom, configLoc, configNm)
+			if err != nil {
+				logger.Warn("lease reclaimer: failed to load config, skipping cycle", logger.Args("err", err.Error()))
+				continue
+			}
 			reclaimed := ReclaimExpiredLeases(ipList, time.Now(), pdns, ddwrt)
 			if len(reclaimed) > 0 {
 				saveConfig(ipList, loadFrom, configLoc, configNm)

--- a/internal/web.go
+++ b/internal/web.go
@@ -55,6 +55,20 @@ func buildFQDN(cluster, zone string) string {
 	return fmt.Sprintf("*.%s.%s", cluster, zone)
 }
 
+// loadProfileHTTP loads the network config for an HTTP request. On failure it
+// logs the error, writes a 500 response, and returns ok=false so the handler
+// can return immediately. This keeps a missing/unreachable config from taking
+// down the whole server — only the affected request fails.
+func loadProfileHTTP(w http.ResponseWriter, loadFrom, configLoc, configNm string) (map[string]IPs, bool) {
+	ipList, err := LoadProfile(loadFrom, configLoc, configNm)
+	if err != nil {
+		log.Printf("FAILED TO LOAD NETWORK CONFIG: %v", err)
+		http.Error(w, "failed to load network config", http.StatusInternalServerError)
+		return nil, false
+	}
+	return ipList, true
+}
+
 // StartWebServer starts the HTTP server for HTMX frontend and REST API
 func StartWebServer(httpPort, loadFrom, configLoc, configNm string, pdns *PDNSClient, ddwrt *DDWRTClient) {
 	mux := http.NewServeMux()
@@ -207,7 +221,10 @@ type dashboardData struct {
 }
 
 func handleDashboard(w http.ResponseWriter, r *http.Request, loadFrom, configLoc, configNm string) {
-	ipList := LoadProfile(loadFrom, configLoc, configNm)
+	ipList, ok := loadProfileHTTP(w, loadFrom, configLoc, configNm)
+	if !ok {
+		return
+	}
 	pools := getPoolInfos(ipList)
 
 	data := dashboardData{
@@ -225,7 +242,10 @@ func handleDashboard(w http.ResponseWriter, r *http.Request, loadFrom, configLoc
 
 func handleNetworkDetail(w http.ResponseWriter, r *http.Request, loadFrom, configLoc, configNm string) {
 	networkKey := r.PathValue("key")
-	ipList := LoadProfile(loadFrom, configLoc, configNm)
+	ipList, ok := loadProfileHTTP(w, loadFrom, configLoc, configNm)
+	if !ok {
+		return
+	}
 
 	ips, ok := ipList[networkKey]
 	if !ok {
@@ -265,7 +285,10 @@ func handleHTMXAssign(w http.ResponseWriter, r *http.Request, loadFrom, configLo
 		return
 	}
 
-	ipList := LoadProfile(loadFrom, configLoc, configNm)
+	ipList, ok := loadProfileHTTP(w, loadFrom, configLoc, configNm)
+	if !ok {
+		return
+	}
 
 	ipKey, err := TruncateIP(ip)
 	if err != nil {
@@ -315,7 +338,10 @@ func handleHTMXRelease(w http.ResponseWriter, r *http.Request, loadFrom, configL
 	ip := r.FormValue("ip")
 	networkKey := r.FormValue("network_key")
 
-	ipList := LoadProfile(loadFrom, configLoc, configNm)
+	ipList, ok := loadProfileHTTP(w, loadFrom, configLoc, configNm)
+	if !ok {
+		return
+	}
 
 	ipKey, err := TruncateIP(ip)
 	if err != nil {
@@ -358,7 +384,10 @@ func handleHTMXRelease(w http.ResponseWriter, r *http.Request, loadFrom, configL
 // --- REST API Handlers ---
 
 func handleAPINetworks(w http.ResponseWriter, r *http.Request, loadFrom, configLoc, configNm string) {
-	ipList := LoadProfile(loadFrom, configLoc, configNm)
+	ipList, ok := loadProfileHTTP(w, loadFrom, configLoc, configNm)
+	if !ok {
+		return
+	}
 	pools := getPoolInfos(ipList)
 
 	w.Header().Set("Content-Type", "application/json")
@@ -367,7 +396,10 @@ func handleAPINetworks(w http.ResponseWriter, r *http.Request, loadFrom, configL
 
 func handleAPINetworkIPs(w http.ResponseWriter, r *http.Request, loadFrom, configLoc, configNm string, pdns *PDNSClient, ddwrt *DDWRTClient) {
 	networkKey := r.PathValue("key")
-	ipList := LoadProfile(loadFrom, configLoc, configNm)
+	ipList, ok := loadProfileHTTP(w, loadFrom, configLoc, configNm)
+	if !ok {
+		return
+	}
 
 	ips, ok := ipList[networkKey]
 	if !ok {
@@ -417,7 +449,10 @@ func handleAPIAssign(w http.ResponseWriter, r *http.Request, loadFrom, configLoc
 		req.Status = "ASSIGNED"
 	}
 
-	ipList := LoadProfile(loadFrom, configLoc, configNm)
+	ipList, ok := loadProfileHTTP(w, loadFrom, configLoc, configNm)
+	if !ok {
+		return
+	}
 
 	if _, ok := ipList[networkKey]; !ok {
 		http.Error(w, `{"error":"network not found"}`, http.StatusNotFound)
@@ -489,7 +524,10 @@ func handleAPIReserve(w http.ResponseWriter, r *http.Request, loadFrom, configLo
 		req.Status = "ASSIGNED"
 	}
 
-	ipList := LoadProfile(loadFrom, configLoc, configNm)
+	ipList, ok := loadProfileHTTP(w, loadFrom, configLoc, configNm)
+	if !ok {
+		return
+	}
 
 	networkIPs, ok := ipList[networkKey]
 	if !ok {
@@ -558,7 +596,10 @@ func handleAPIRelease(w http.ResponseWriter, r *http.Request, loadFrom, configLo
 		return
 	}
 
-	ipList := LoadProfile(loadFrom, configLoc, configNm)
+	ipList, ok := loadProfileHTTP(w, loadFrom, configLoc, configNm)
+	if !ok {
+		return
+	}
 
 	if _, ok := ipList[networkKey]; !ok {
 		http.Error(w, `{"error":"network not found"}`, http.StatusNotFound)
@@ -613,7 +654,10 @@ func handleAPIRenewLease(w http.ResponseWriter, r *http.Request, loadFrom, confi
 		return
 	}
 
-	ipList := LoadProfile(loadFrom, configLoc, configNm)
+	ipList, ok := loadProfileHTTP(w, loadFrom, configLoc, configNm)
+	if !ok {
+		return
+	}
 
 	if _, ok := ipList[networkKey]; !ok {
 		http.Error(w, `{"error":"network not found"}`, http.StatusNotFound)
@@ -664,7 +708,10 @@ func handleAPICreateNetwork(w http.ResponseWriter, r *http.Request, loadFrom, co
 		return
 	}
 
-	ipList := LoadProfile(loadFrom, configLoc, configNm)
+	ipList, ok := loadProfileHTTP(w, loadFrom, configLoc, configNm)
+	if !ok {
+		return
+	}
 
 	// CIDR mode: expand CIDR notation into networks
 	if req.CIDR != "" {
@@ -752,7 +799,10 @@ func handleAPICreateNetworkFromCIDR(w http.ResponseWriter, r *http.Request, load
 		return
 	}
 
-	ipList := LoadProfile(loadFrom, configLoc, configNm)
+	ipList, ok := loadProfileHTTP(w, loadFrom, configLoc, configNm)
+	if !ok {
+		return
+	}
 
 	createdKeys := []string{}
 	totalIPs := 0
@@ -785,7 +835,10 @@ func handleAPICreateNetworkFromCIDR(w http.ResponseWriter, r *http.Request, load
 
 func handleAPIDeleteNetwork(w http.ResponseWriter, r *http.Request, loadFrom, configLoc, configNm string) {
 	networkKey := r.PathValue("key")
-	ipList := LoadProfile(loadFrom, configLoc, configNm)
+	ipList, ok := loadProfileHTTP(w, loadFrom, configLoc, configNm)
+	if !ok {
+		return
+	}
 
 	if _, ok := ipList[networkKey]; !ok {
 		http.Error(w, `{"error":"network not found"}`, http.StatusNotFound)
@@ -819,7 +872,10 @@ func handleAPIAddIP(w http.ResponseWriter, r *http.Request, loadFrom, configLoc,
 		return
 	}
 
-	ipList := LoadProfile(loadFrom, configLoc, configNm)
+	ipList, ok := loadProfileHTTP(w, loadFrom, configLoc, configNm)
+	if !ok {
+		return
+	}
 
 	if _, ok := ipList[networkKey]; !ok {
 		http.Error(w, `{"error":"network not found"}`, http.StatusNotFound)
@@ -852,7 +908,10 @@ func handleAPIDeleteIP(w http.ResponseWriter, r *http.Request, loadFrom, configL
 		ip = strings.TrimPrefix(ip, networkKey+".")
 	}
 
-	ipList := LoadProfile(loadFrom, configLoc, configNm)
+	ipList, ok := loadProfileHTTP(w, loadFrom, configLoc, configNm)
+	if !ok {
+		return
+	}
 
 	network, ok := ipList[networkKey]
 	if !ok {
@@ -917,7 +976,10 @@ func handleAPIEditIP(w http.ResponseWriter, r *http.Request, loadFrom, configLoc
 		return
 	}
 
-	ipList := LoadProfile(loadFrom, configLoc, configNm)
+	ipList, ok := loadProfileHTTP(w, loadFrom, configLoc, configNm)
+	if !ok {
+		return
+	}
 
 	network, ok := ipList[networkKey]
 	if !ok {
@@ -968,7 +1030,10 @@ func handleAPIEditIP(w http.ResponseWriter, r *http.Request, loadFrom, configLoc
 // --- Cluster Info Handlers ---
 
 func handleAPIClusters(w http.ResponseWriter, r *http.Request, loadFrom, configLoc, configNm string) {
-	ipList := LoadProfile(loadFrom, configLoc, configNm)
+	ipList, ok := loadProfileHTTP(w, loadFrom, configLoc, configNm)
+	if !ok {
+		return
+	}
 
 	clusters := map[string][]map[string]string{}
 	for networkKey, ips := range ipList {
@@ -999,7 +1064,10 @@ func handleAPIClusters(w http.ResponseWriter, r *http.Request, loadFrom, configL
 
 func handleAPIClusterInfo(w http.ResponseWriter, r *http.Request, loadFrom, configLoc, configNm string, pdns *PDNSClient, ddwrt *DDWRTClient) {
 	clusterName := r.PathValue("name")
-	ipList := LoadProfile(loadFrom, configLoc, configNm)
+	ipList, ok := loadProfileHTTP(w, loadFrom, configLoc, configNm)
+	if !ok {
+		return
+	}
 
 	type ipInfo struct {
 		Network string `json:"network"`
@@ -1103,7 +1171,10 @@ func handleHTMXAddNetwork(w http.ResponseWriter, r *http.Request, loadFrom, conf
 		return
 	}
 
-	ipList := LoadProfile(loadFrom, configLoc, configNm)
+	ipList, ok := loadProfileHTTP(w, loadFrom, configLoc, configNm)
+	if !ok {
+		return
+	}
 
 	if _, exists := ipList[network]; exists {
 		http.Error(w, "Network already exists", http.StatusConflict)
@@ -1136,7 +1207,10 @@ func handleHTMXAddIP(w http.ResponseWriter, r *http.Request, loadFrom, configLoc
 		return
 	}
 
-	ipList := LoadProfile(loadFrom, configLoc, configNm)
+	ipList, ok := loadProfileHTTP(w, loadFrom, configLoc, configNm)
+	if !ok {
+		return
+	}
 
 	if _, ok := ipList[networkKey]; !ok {
 		http.Error(w, "Network not found", http.StatusNotFound)
@@ -1174,7 +1248,10 @@ func handleHTMXDeleteIP(w http.ResponseWriter, r *http.Request, loadFrom, config
 		return
 	}
 
-	ipList := LoadProfile(loadFrom, configLoc, configNm)
+	ipList, ok := loadProfileHTTP(w, loadFrom, configLoc, configNm)
+	if !ok {
+		return
+	}
 
 	ipDigit, err := GetLastIPDigit(ip)
 	if err != nil {
@@ -1223,7 +1300,10 @@ func handleHTMXEdit(w http.ResponseWriter, r *http.Request, loadFrom, configLoc,
 		return
 	}
 
-	ipList := LoadProfile(loadFrom, configLoc, configNm)
+	ipList, ok := loadProfileHTTP(w, loadFrom, configLoc, configNm)
+	if !ok {
+		return
+	}
 
 	ipKey, err := TruncateIP(ip)
 	if err != nil {
@@ -1310,7 +1390,10 @@ func handleHTMXDeleteNetwork(w http.ResponseWriter, r *http.Request, loadFrom, c
 
 	networkKey := r.FormValue("network_key")
 
-	ipList := LoadProfile(loadFrom, configLoc, configNm)
+	ipList, ok := loadProfileHTTP(w, loadFrom, configLoc, configNm)
+	if !ok {
+		return
+	}
 	delete(ipList, networkKey)
 	saveConfig(ipList, loadFrom, configLoc, configNm)
 

--- a/internal/web_test.go
+++ b/internal/web_test.go
@@ -277,7 +277,10 @@ func TestHandleAPIAssignWithLease(t *testing.T) {
 		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
 	}
 
-	ipList := LoadProfile("disk", dir, name)
+	ipList, err := LoadProfile("disk", dir, name)
+	if err != nil {
+		t.Fatalf("LoadProfile: %v", err)
+	}
 	entry := ipList["10.31.103"]["7"]
 	if entry.Status != "ASSIGNED" || entry.Cluster != "newcluster" {
 		t.Errorf("entry not assigned: %+v", entry)
@@ -331,7 +334,10 @@ func TestHandleAPIReserveAcceptsCamelCaseCreateDNS(t *testing.T) {
 	}
 
 	// Persisted entry should match — cluster kept intact, :DNS suffix set.
-	ipList := LoadProfile("disk", dir, name)
+	ipList, err := LoadProfile("disk", dir, name)
+	if err != nil {
+		t.Fatalf("LoadProfile: %v", err)
+	}
 	digit := strings.TrimPrefix(resp.IP, "10.31.103.")
 	entry := ipList["10.31.103"][digit]
 	if entry.Cluster != "smoke-alloc" {
@@ -356,7 +362,11 @@ func TestHandleAPIAssignAcceptsCamelCaseCreateDNS(t *testing.T) {
 		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
 	}
 
-	entry := LoadProfile("disk", dir, name)["10.31.103"]["7"]
+	profile, err := LoadProfile("disk", dir, name)
+	if err != nil {
+		t.Fatalf("LoadProfile: %v", err)
+	}
+	entry := profile["10.31.103"]["7"]
 	if entry.Cluster != "smoke-assign" {
 		t.Errorf("cluster: got %q, want %q", entry.Cluster, "smoke-assign")
 	}
@@ -381,7 +391,11 @@ func TestHandleAPIEditIPDoesNotDoubleSuffixDNS(t *testing.T) {
 		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
 	}
 
-	entry := LoadProfile("disk", dir, name)["10.31.103"]["6"]
+	profile, err := LoadProfile("disk", dir, name)
+	if err != nil {
+		t.Fatalf("LoadProfile: %v", err)
+	}
+	entry := profile["10.31.103"]["6"]
 	if entry.Status != "ASSIGNED:DNS" {
 		t.Errorf("status: got %q, want %q (no double :DNS)", entry.Status, "ASSIGNED:DNS")
 	}
@@ -449,7 +463,10 @@ func TestHandleAPIRenewLease(t *testing.T) {
 		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
 	}
 
-	ipList := LoadProfile("disk", dir, name)
+	ipList, err := LoadProfile("disk", dir, name)
+	if err != nil {
+		t.Fatalf("LoadProfile: %v", err)
+	}
 	entry := ipList["10.31.103"]["6"]
 	if entry.LeaseExpiresAt < before+7200 || entry.LeaseExpiresAt > after+7200 {
 		t.Errorf("unexpected LeaseExpiresAt after renew: %d", entry.LeaseExpiresAt)
@@ -492,7 +509,10 @@ func TestHandleAPIReleaseClearsLease(t *testing.T) {
 		t.Fatalf("expected 200, got %d", w.Code)
 	}
 
-	ipList := LoadProfile("disk", dir, name)
+	ipList, err := LoadProfile("disk", dir, name)
+	if err != nil {
+		t.Fatalf("LoadProfile: %v", err)
+	}
 	entry := ipList["10.31.103"]["7"]
 	if entry.LeaseExpiresAt != 0 {
 		t.Errorf("expected lease cleared after release, got %d", entry.LeaseExpiresAt)

--- a/main.go
+++ b/main.go
@@ -66,7 +66,11 @@ func (s *server) GetIpAddressRange(ctx context.Context, req *ipservice.IpRequest
 	}
 
 	// READ NetworkConfig FROM STATIC YAML FILE
-	ipList := internal.LoadProfile(loadConfigFrom, configLocation, configName)
+	ipList, err := internal.LoadProfile(loadConfigFrom, configLocation, configName)
+	if err != nil {
+		logger.Error("FAILED TO LOAD CONFIG", logger.Args("err", err.Error()))
+		return nil, err
+	}
 	fmt.Println("NETWORKS FROM STATC YAML FILE:", ipList)
 
 	availableAddresses, err := internal.GenerateIPs(ipList, int(req.CountIpAddresses), req.NetworkKey)
@@ -88,7 +92,11 @@ func (s *server) SetClusterInfo(ctx context.Context, req *ipservice.ClusterReque
 	logger.Info("CONFIG FILE PATH", logger.Args("", configLocation+"/"+configName))
 
 	// LOAD EXISTING YAML FILE
-	ipList := internal.LoadProfile(loadConfigFrom, configLocation, configName)
+	ipList, err := internal.LoadProfile(loadConfigFrom, configLocation, configName)
+	if err != nil {
+		logger.Error("FAILED TO LOAD CONFIG", logger.Args("err", err.Error()))
+		return nil, err
+	}
 
 	// GET IPS FROM REQUEST
 	ips := strings.Split(req.IpAddressRange, ";")


### PR DESCRIPTION
## Problem

The `clusterbook` Deployment was crash-looping (`MinimumReplicasUnavailable`, gateway returning `connection refused` / `upstream connect error`).

Root cause: `LoadProfile` called `log.Fatalf` on any config-load error, and the lease reclaimer goroutine calls it every minute. With `LOAD_CONFIG_FROM=cr` and the `networks-labul` NetworkConfig CR not present in the cluster, the reclaimer fired ~1 min after startup and terminated the whole process — repeatedly. The TCP readiness probe couldn't catch it because the gRPC socket binds fine at startup; only the later `Fatalf` killed the pod.

## Changes

1. **`LoadProfile` returns `(map[string]IPs, error)` instead of `log.Fatalf`.** Callers degrade gracefully:
   - reclaimer: logs a warning and skips the cycle
   - web handlers: respond `500` via a `loadProfileHTTP` helper; the server stays up
   - gRPC handlers: return the error to the caller

2. **A not-found CR is treated as empty state, not an error.** The app already self-bootstraps the CR on first write (`CreateOrUpdateNetworkConfig` creates it when missing), so on read a missing CR now yields an empty network map plus a log line. The dashboard comes up empty and the CR is created the first time a network/IP is added.

Real API errors (auth, connectivity, missing CRD) are still surfaced — only "resource not found" is treated as empty.

## Why not ship a sample CR via GitOps

The NetworkConfig CR is mutable runtime state (the app writes IP assignments and lease data into it). A GitOps-managed sample would be reverted by Flux on every reconcile, wiping live assignments. Self-bootstrapping avoids that conflict entirely.

## Testing

- `go build ./...`, `go vet ./...`, and `go test ./...` all pass.
- Existing handler/reclaimer/load tests updated for the new signature.

Note: the not-found branch isn't unit-tested because `GetNetworkConfig` builds a live dynamic client from `KUBECONFIG` and isn't mockable without refactoring the client wiring. Happy to follow up by making the client injectable (mirroring the `SSHExecutor` pattern) for coverage.

https://claude.ai/code/session_01K2cLqBCQYsMhMcweKpyDW5

---
_Generated by [Claude Code](https://claude.ai/code/session_01K2cLqBCQYsMhMcweKpyDW5)_