### PR TITLE
fix: support DD-WRT in DNS test and stop swallowing DD-WRT errors

### DIFF
--- a/internal/ddwrt.go
+++ b/internal/ddwrt.go
@@ -58,10 +58,17 @@ func newDDWRTClientWithExecutor(zone string, exec SSHExecutor) *DDWRTClient {
 }
 
 // CreateRecord adds/updates a dnsmasq address entry on DD-WRT via SSH.
-func (d *DDWRTClient) CreateRecord(hostname, ip string) error {
+// Errors are logged here (not just returned) so failures are never silent,
+// mirroring how PDNSClient self-logs inside patchZone.
+func (d *DDWRTClient) CreateRecord(hostname, ip string) (err error) {
 	fqdn := fmt.Sprintf("%s.%s", hostname, d.Zone)
 	newEntry := fmt.Sprintf("address=/%s/%s", fqdn, ip)
 	d.logger.Info("DDWRT CREATE DNS RECORD", d.logger.Args("fqdn", fqdn, "ip", ip))
+	defer func() {
+		if err != nil {
+			d.logger.Error("DDWRT CREATE DNS RECORD FAILED", d.logger.Args("fqdn", fqdn, "ip", ip, "err", err.Error()))
+		}
+	}()
 
 	exec, cleanup, err := d.getExecutor()
 	if err != nil {
@@ -86,9 +93,15 @@ func (d *DDWRTClient) CreateRecord(hostname, ip string) error {
 }
 
 // DeleteRecord removes a dnsmasq address entry from DD-WRT via SSH.
-func (d *DDWRTClient) DeleteRecord(hostname string) error {
+// Errors are logged here (not just returned) so failures are never silent.
+func (d *DDWRTClient) DeleteRecord(hostname string) (err error) {
 	fqdn := fmt.Sprintf("%s.%s", hostname, d.Zone)
 	d.logger.Info("DDWRT DELETE DNS RECORD", d.logger.Args("fqdn", fqdn))
+	defer func() {
+		if err != nil {
+			d.logger.Error("DDWRT DELETE DNS RECORD FAILED", d.logger.Args("fqdn", fqdn, "err", err.Error()))
+		}
+	}()
 
 	exec, cleanup, err := d.getExecutor()
 	if err != nil {
@@ -110,6 +123,37 @@ func (d *DDWRTClient) DeleteRecord(hostname string) error {
 
 	d.logger.Info("DDWRT DNS RECORD DELETED", d.logger.Args("fqdn", fqdn))
 	return nil
+}
+
+// TestDNS verifies the dnsmasq address entry for the cluster's FQDN exists on
+// DD-WRT and resolves to the expected IP. It reads dnsmasq_options over SSH and
+// inspects the managed `address=/{fqdn}/{ip}` record directly — an in-cluster
+// net.LookupHost would hit the pod resolver (CoreDNS), not the DD-WRT router.
+// Returns (fqdn, resolvedIP, match, error), mirroring PDNSClient.TestDNS.
+func (d *DDWRTClient) TestDNS(cluster, expectedIP string) (string, string, bool, error) {
+	if d == nil {
+		return "", "", false, fmt.Errorf("DDWRT not enabled")
+	}
+
+	fqdn := fmt.Sprintf("%s.%s", cluster, d.Zone)
+
+	exec, cleanup, err := d.getExecutor()
+	if err != nil {
+		return fqdn, "", false, fmt.Errorf("ddwrt ssh connect: %w", err)
+	}
+	defer cleanup()
+
+	existing, err := exec.Run("nvram get dnsmasq_options")
+	if err != nil {
+		return fqdn, "", false, fmt.Errorf("ddwrt read dnsmasq_options: %w", err)
+	}
+
+	resolved := lookupDNSEntry(existing, fqdn)
+	if resolved == "" {
+		return fqdn, "", false, fmt.Errorf("no dnsmasq entry for %s", fqdn)
+	}
+
+	return fqdn, resolved, resolved == expectedIP, nil
 }
 
 // getExecutor returns injected executor (tests) or a fresh real SSH executor.
@@ -170,6 +214,19 @@ func mergeDNSEntry(existing, newEntry, fqdn string) string {
 		lines = append(lines, line)
 	}
 	return strings.Join(append(lines, newEntry), "\n")
+}
+
+// lookupDNSEntry returns the IP of the `address=/{fqdn}/{ip}` entry in
+// dnsmasq_options content, or "" if no matching entry exists.
+func lookupDNSEntry(existing, fqdn string) string {
+	marker := "/" + fqdn + "/"
+	for _, line := range strings.Split(existing, "\n") {
+		line = strings.TrimSpace(line)
+		if idx := strings.Index(line, marker); idx >= 0 {
+			return line[idx+len(marker):]
+		}
+	}
+	return ""
 }
 
 func removeDNSEntry(existing, fqdn string) string {

--- a/internal/ddwrt_test.go
+++ b/internal/ddwrt_test.go
@@ -67,6 +67,20 @@ func TestRemoveDNSEntry_NotPresent(t *testing.T) {
 	}
 }
 
+func TestLookupDNSEntry_Found(t *testing.T) {
+	existing := "address=/myapp.sthings.lab/10.31.103.6\naddress=/other.sthings.lab/10.31.103.7"
+	if ip := lookupDNSEntry(existing, "myapp.sthings.lab"); ip != "10.31.103.6" {
+		t.Errorf("expected 10.31.103.6, got %q", ip)
+	}
+}
+
+func TestLookupDNSEntry_NotFound(t *testing.T) {
+	existing := "address=/other.sthings.lab/10.31.103.7"
+	if ip := lookupDNSEntry(existing, "myapp.sthings.lab"); ip != "" {
+		t.Errorf("expected empty result, got %q", ip)
+	}
+}
+
 // ── Unit tests: mock executor (no network) ────────────────────────────────────
 
 // fakeExecutor implements SSHExecutor in memory — no SSH, no network.
@@ -169,6 +183,49 @@ func TestDDWRTClient_MultipleRecords_Mock(t *testing.T) {
 	}
 }
 
+func TestDDWRTClient_TestDNS_Match_Mock(t *testing.T) {
+	exec := newFakeExecutor()
+	client := newDDWRTClientWithExecutor("sthings.lab", exec)
+	client.CreateRecord("myapp", "10.31.103.6")
+
+	fqdn, resolved, match, err := client.TestDNS("myapp", "10.31.103.6")
+	if err != nil {
+		t.Fatalf("TestDNS failed: %v", err)
+	}
+	if fqdn != "myapp.sthings.lab" {
+		t.Errorf("unexpected fqdn: %q", fqdn)
+	}
+	if resolved != "10.31.103.6" || !match {
+		t.Errorf("expected match on 10.31.103.6, got resolved=%q match=%v", resolved, match)
+	}
+}
+
+func TestDDWRTClient_TestDNS_Mismatch_Mock(t *testing.T) {
+	exec := newFakeExecutor()
+	client := newDDWRTClientWithExecutor("sthings.lab", exec)
+	client.CreateRecord("myapp", "10.31.103.6")
+
+	_, resolved, match, err := client.TestDNS("myapp", "10.31.103.99")
+	if err != nil {
+		t.Fatalf("TestDNS failed: %v", err)
+	}
+	if match {
+		t.Error("expected no match for differing IP")
+	}
+	if resolved != "10.31.103.6" {
+		t.Errorf("expected resolved 10.31.103.6, got %q", resolved)
+	}
+}
+
+func TestDDWRTClient_TestDNS_Missing_Mock(t *testing.T) {
+	exec := newFakeExecutor()
+	client := newDDWRTClientWithExecutor("sthings.lab", exec)
+
+	if _, _, _, err := client.TestDNS("myapp", "10.31.103.6"); err == nil {
+		t.Error("expected error when no entry exists")
+	}
+}
+
 // ── Integration tests: fake SSH server (real SSH stack, fake nvram) ───────────
 
 func TestDDWRTClient_CreateRecord_FakeSSH(t *testing.T) {
@@ -254,6 +311,32 @@ func TestDDWRTClient_Idempotent_FakeSSH(t *testing.T) {
 	}
 	if !strings.Contains(opts, "10.31.103.6") {
 		t.Errorf("expected updated IP, got: %q", opts)
+	}
+}
+
+func TestDDWRTClient_TestDNS_FakeSSH(t *testing.T) {
+	srv, err := NewFakeDDWRTServer("root", "testpass")
+	if err != nil {
+		t.Fatalf("start fake server: %v", err)
+	}
+	defer srv.Close()
+
+	srv.NvramSet("dnsmasq_options", "address=/myapp.sthings.lab/10.31.103.6")
+
+	client := &DDWRTClient{
+		Host:     srv.Addr,
+		User:     "root",
+		Password: "testpass",
+		Zone:     "sthings.lab",
+		logger:   pterm.DefaultLogger.WithLevel(pterm.LogLevelTrace),
+	}
+
+	fqdn, resolved, match, err := client.TestDNS("myapp", "10.31.103.6")
+	if err != nil {
+		t.Fatalf("TestDNS failed: %v", err)
+	}
+	if fqdn != "myapp.sthings.lab" || resolved != "10.31.103.6" || !match {
+		t.Errorf("unexpected result: fqdn=%q resolved=%q match=%v", fqdn, resolved, match)
 	}
 }
 

--- a/internal/web.go
+++ b/internal/web.go
@@ -159,7 +159,7 @@ func StartWebServer(httpPort, loadFrom, configLoc, configNm string, pdns *PDNSCl
 		handleHTMXDeleteNetwork(w, r, loadFrom, configLoc, configNm)
 	})
 	mux.HandleFunc("POST /htmx/test-dns", func(w http.ResponseWriter, r *http.Request) {
-		handleHTMXTestDNS(w, r, pdns)
+		handleHTMXTestDNS(w, r, pdns, ddwrt)
 	})
 
 	log.Printf("HTTP/HTMX SERVER LISTENING AT :%s", httpPort)
@@ -1355,7 +1355,7 @@ func handleHTMXEdit(w http.ResponseWriter, r *http.Request, loadFrom, configLoc,
 	}{networkKey, entries})
 }
 
-func handleHTMXTestDNS(w http.ResponseWriter, r *http.Request, pdns *PDNSClient) {
+func handleHTMXTestDNS(w http.ResponseWriter, r *http.Request, pdns *PDNSClient, ddwrt *DDWRTClient) {
 	if err := r.ParseForm(); err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
@@ -1369,7 +1369,23 @@ func handleHTMXTestDNS(w http.ResponseWriter, r *http.Request, pdns *PDNSClient)
 		return
 	}
 
-	fqdn, resolved, match, err := pdns.TestDNS(cluster, expectedIP)
+	// Test against whichever DNS provider is enabled. PDNS takes precedence;
+	// fall back to DD-WRT so DD-WRT-only deployments can verify records too.
+	var (
+		fqdn, resolved string
+		match          bool
+		err            error
+	)
+	switch {
+	case pdns != nil:
+		fqdn, resolved, match, err = pdns.TestDNS(cluster, expectedIP)
+	case ddwrt != nil:
+		fqdn, resolved, match, err = ddwrt.TestDNS(cluster, expectedIP)
+	default:
+		fmt.Fprintf(w, `<span style="color:#f97316;font-size:0.75rem;">no DNS provider enabled</span>`)
+		return
+	}
+
 	if err != nil {
 		fmt.Fprintf(w, `<span style="color:#ef4444;font-size:0.75rem;" title="%s">DNS FAIL</span>`, err.Error())
 		return

--- a/internal/web.go
+++ b/internal/web.go
@@ -1006,14 +1006,16 @@ func handleAPIEditIP(w http.ResponseWriter, r *http.Request, loadFrom, configLoc
 
 	saveConfig(ipList, loadFrom, configLoc, configNm)
 
-	// Handle DNS changes
+	// Handle DNS changes. Remove the old record when DNS is turned off or the
+	// cluster changed. When DNS is on, always (re)create — both providers are
+	// idempotent, so re-saving reconciles a record that drifted from the router.
 	if hadDNS && (!req.CreateDNS || prevCluster != req.Cluster) {
 		pdns.DeleteRecord(prevCluster)
 		if ddwrt != nil {
 			ddwrt.DeleteRecord(prevCluster)
 		}
 	}
-	if req.CreateDNS && (!hadDNS || prevCluster != req.Cluster) {
+	if req.CreateDNS {
 		pdns.CreateRecord(req.Cluster, networkKey+"."+ipDigit)
 		if ddwrt != nil {
 			ddwrt.CreateRecord(req.Cluster, networkKey+"."+ipDigit)
@@ -1331,14 +1333,16 @@ func handleHTMXEdit(w http.ResponseWriter, r *http.Request, loadFrom, configLoc,
 
 	saveConfig(ipList, loadFrom, configLoc, configNm)
 
-	// Handle DNS changes
+	// Handle DNS changes. Remove the old record when DNS is turned off or the
+	// cluster changed. When DNS is on, always (re)create — both providers are
+	// idempotent, so re-saving reconciles a record that drifted from the router.
 	if hadDNS && (!createDNS || prevCluster != cluster) {
 		pdns.DeleteRecord(prevCluster)
 		if ddwrt != nil {
 			ddwrt.DeleteRecord(prevCluster)
 		}
 	}
-	if createDNS && (!hadDNS || prevCluster != cluster) {
+	if createDNS {
 		pdns.CreateRecord(cluster, ipKey+"."+ipDigit)
 		if ddwrt != nil {
 			ddwrt.CreateRecord(cluster, ipKey+"."+ipDigit)


### PR DESCRIPTION
## Problem

On a DD-WRT-only deployment (PDNS disabled), assigning an IP with DNS showed `ASSIGNED:DNS` in the UI, but the **DNS "Test" button always rendered `DNS FAIL`**, the logs showed nothing, and no entry appeared on the router.

Two separate bugs:

1. **DNS test had no DD-WRT path.** `/htmx/test-dns` only ever called `pdns.TestDNS(...)`. With PDNS disabled (`pdns == nil`) it returned `"PDNS not enabled"` → red `DNS FAIL`, regardless of whether the DD-WRT record actually existed.

2. **DD-WRT errors were silently dropped.** Every call site discarded the error from `ddwrt.CreateRecord(...)` / `DeleteRecord(...)`. The methods logged only on start/success, so a failed SSH connect or `nvram` write left no trace in the logs and no record on the router. (PDNS self-logs failures inside `patchZone`; DD-WRT didn't.)

## Changes

- **DD-WRT DNS test support** — route the DD-WRT client into `handleHTMXTestDNS` and add `DDWRTClient.TestDNS`, which SSHes in, reads `dnsmasq_options`, and verifies the managed `address=/{cluster}.{zone}/{ip}` entry resolves to the expected IP. It inspects `nvram` directly rather than `net.LookupHost`, because in-cluster a real lookup hits CoreDNS, not the router. The handler now prefers PDNS, falls back to DD-WRT, else reports "no DNS provider enabled".
- **Surface DD-WRT errors** — `CreateRecord`/`DeleteRecord` now log a `DDWRT ... FAILED` error (fqdn/ip/err) via `defer`, matching the PDNS self-logging convention.
- **Reconcile on edit** — re-saving an assignment with DNS enabled now always (re)creates the record instead of skipping when the cluster was unchanged. Both providers are idempotent (PDNS `REPLACE`, DD-WRT dedupe-by-FQDN), so this repairs records that drifted from the router after a silent failure.

## Tests

Added coverage across the project's three layers — pure helper (`lookupDNSEntry`), mock executor, and fake-SSH server — for `TestDNS` match / mismatch / missing cases. `go build`, `go vet`, and the full `internal` suite pass.

https://claude.ai/code/session_011PL46pSCWGHk57owAiXjUL

---
_Generated by [Claude Code](https://claude.ai/code/session_011PL46pSCWGHk57owAiXjUL)_